### PR TITLE
rename whitespace param to be more accurate

### DIFF
--- a/src/DotNetEnv/Env.cs
+++ b/src/DotNetEnv/Env.cs
@@ -4,13 +4,13 @@ namespace DotNetEnv
 {
     public class Env
     {
-        public static void Load(string path)
+        public static void Load(string path, bool keepWhiteSpace = false)
         {
-            Vars envFile = Parser.Parse(File.ReadAllLines(path));
+            Vars envFile = Parser.Parse(File.ReadAllLines(path), keepWhiteSpace);
             LoadVars.SetEnvironmentVariables(envFile);
         }
 
-        public static void Load()
-            => Load(Path.Combine(Directory.GetCurrentDirectory(), ".env"));
+        public static void Load(bool keepWhiteSpace = false)
+            => Load(Path.Combine(Directory.GetCurrentDirectory(), ".env"), keepWhiteSpace);
     }
 }

--- a/src/DotNetEnv/Parser.cs
+++ b/src/DotNetEnv/Parser.cs
@@ -25,7 +25,7 @@ namespace DotNetEnv
             return line.Substring(7);
         }
 
-        public static Vars Parse(string[] lines, bool ignoreWhiteSpace = false)
+        public static Vars Parse(string[] lines, bool keepWhiteSpace = false)
         {
             Vars vars = new Vars();
 
@@ -46,7 +46,7 @@ namespace DotNetEnv
                 if (keyValuePair.Length != 2)
                     continue;
 
-                if (!ignoreWhiteSpace)
+                if (!keepWhiteSpace)
                 {
                     keyValuePair[0] = keyValuePair[0].Trim();
                     keyValuePair[1] = keyValuePair[1].Trim();

--- a/test/DotNetEnv.Tests/.env
+++ b/test/DotNetEnv.Tests/.env
@@ -2,3 +2,4 @@
 NAME=Toni #inline comment
 URL=https://github.com/tonerdo
 CONNECTION=user=test;password=secret
+WHITEBOTH=  leading and trailing white space   

--- a/test/DotNetEnv.Tests/.env2
+++ b/test/DotNetEnv.Tests/.env2
@@ -2,3 +2,4 @@
 IP=127.0.0.1
 PORT=8080
 export DOMAIN=example.com
+WHITELEAD=  leading white space followed by comment  # comment

--- a/test/DotNetEnv.Tests/EnvTests.cs
+++ b/test/DotNetEnv.Tests/EnvTests.cs
@@ -12,6 +12,7 @@ namespace DotNetEnv.Tests
             Assert.Equal(Environment.GetEnvironmentVariable("NAME"), "Toni");
             Assert.Equal(Environment.GetEnvironmentVariable("URL"), "https://github.com/tonerdo");
             Assert.Equal(Environment.GetEnvironmentVariable("CONNECTION"), "user=test;password=secret");
+            Assert.Equal(Environment.GetEnvironmentVariable("WHITEBOTH"), "leading and trailing white space");
         }
 
         [Fact]
@@ -21,6 +22,25 @@ namespace DotNetEnv.Tests
             Assert.Equal(Environment.GetEnvironmentVariable("IP"), "127.0.0.1");
             Assert.Equal(Environment.GetEnvironmentVariable("PORT"), "8080");
             Assert.Equal(Environment.GetEnvironmentVariable("DOMAIN"), "example.com");
+            Assert.Equal(Environment.GetEnvironmentVariable("WHITELEAD"), "leading white space followed by comment");
+        }
+
+        [Fact]
+        public void LoadArgsTest()
+        {
+            DotNetEnv.Env.Load(false);
+            Assert.Equal(Environment.GetEnvironmentVariable("WHITEBOTH"), "leading and trailing white space");
+            DotNetEnv.Env.Load(true);
+            Assert.Equal(Environment.GetEnvironmentVariable("WHITEBOTH"), "  leading and trailing white space   ");
+        }
+
+        [Fact]
+        public void LoadPathArgsTest()
+        {
+            DotNetEnv.Env.Load("./.env2", false);
+            Assert.Equal(Environment.GetEnvironmentVariable("WHITELEAD"), "leading white space followed by comment");
+            DotNetEnv.Env.Load("./.env2", true);
+            Assert.Equal(Environment.GetEnvironmentVariable("WHITELEAD"), "  leading white space followed by comment  ");
         }
     }
 }


### PR DESCRIPTION
When you wanted to ignore whitepace, the param `ignoreWhiteSpace` was set to `false` and if you wanted to keep whitespace that param was set to `true` which strikes me as backwards, so I have renamed it for clarity.

I also noted that this is an internal class' method returning an instance of an internal class, with no way to pass a value to this param in normal use, so testing this is a bit of a hassle, so I have chosen not to do it.