### PR TITLE
rename whitespace in value param, add allow hash in value param, expose and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,55 @@ The variables in the `.env` can then be accessed through the `System.Environment
 System.Environment.GetEnvironmentVariable("IP")
 ```
 
+
+### Additional arguments
+
+You can also control whitespace trimming and allowing hashes in values
+```csharp
+DotNetEnv.Env.Load(false, false);
+```
+
+Both parameters default to true, which means:
+1. `trimWhitespace`, first arg: true in order to trim
+ leading and trailing whitespace from keys and values such that
+
+```env
+  KEY  =  value
+```
+
+Would then be available as
+```csharp
+"value" == System.Environment.GetEnvironmentVariable("KEY")
+null == System.Environment.GetEnvironmentVariable("  KEY  ")
+```
+
+False would mean:
+```csharp
+"  value" == System.Environment.GetEnvironmentVariable("  KEY  ")
+null == System.Environment.GetEnvironmentVariable("KEY")
+```
+
+2. `isEmbeddedHashComment`, second arg: true in order to allow inline comments
+
+```env
+KEY=value  # comment
+```
+
+Would then be available as
+```csharp
+"value" == System.Environment.GetEnvironmentVariable("KEY")
+```
+
+False would mean:
+```csharp
+"value  # comment" == System.Environment.GetEnvironmentVariable("KEY")
+```
+
+Which is most useful when you want to do something like:
+```env
+KEY=value#moreValue#otherValue#etc
+```
+
 ## Issue Reporting
 
 If you have found a bug or if you have a feature request, please report them at this repository issues section.

--- a/src/DotNetEnv/Env.cs
+++ b/src/DotNetEnv/Env.cs
@@ -4,13 +4,13 @@ namespace DotNetEnv
 {
     public class Env
     {
-        public static void Load(string path)
+        public static void Load(string path, bool trimWhitespace = true, bool isEmbeddedHashComment = true)
         {
-            Vars envFile = Parser.Parse(File.ReadAllLines(path));
+            Vars envFile = Parser.Parse(File.ReadAllLines(path), trimWhitespace, isEmbeddedHashComment);
             LoadVars.SetEnvironmentVariables(envFile);
         }
 
-        public static void Load()
-            => Load(Path.Combine(Directory.GetCurrentDirectory(), ".env"));
+        public static void Load(bool trimWhitespace = true, bool isEmbeddedHashComment = true)
+            => Load(Path.Combine(Directory.GetCurrentDirectory(), ".env"), trimWhitespace, isEmbeddedHashComment);
     }
 }

--- a/test/DotNetEnv.Tests/.env
+++ b/test/DotNetEnv.Tests/.env
@@ -2,3 +2,5 @@
 NAME=Toni #inline comment
 URL=https://github.com/tonerdo
 CONNECTION=user=test;password=secret
+  WHITEBOTH  =  leading and trailing white space   
+PASSWORD=Google#Facebook

--- a/test/DotNetEnv.Tests/.env2
+++ b/test/DotNetEnv.Tests/.env2
@@ -2,3 +2,6 @@
 IP=127.0.0.1
 PORT=8080
 export DOMAIN=example.com
+EMBEDEXPORT=some text export other text
+  #COMMENTLEAD=not used
+WHITELEAD=  leading white space followed by comment  # comment

--- a/test/DotNetEnv.Tests/EnvTests.cs
+++ b/test/DotNetEnv.Tests/EnvTests.cs
@@ -12,6 +12,7 @@ namespace DotNetEnv.Tests
             Assert.Equal(Environment.GetEnvironmentVariable("NAME"), "Toni");
             Assert.Equal(Environment.GetEnvironmentVariable("URL"), "https://github.com/tonerdo");
             Assert.Equal(Environment.GetEnvironmentVariable("CONNECTION"), "user=test;password=secret");
+            Assert.Equal(Environment.GetEnvironmentVariable("WHITEBOTH"), "leading and trailing white space");
         }
 
         [Fact]
@@ -21,6 +22,35 @@ namespace DotNetEnv.Tests
             Assert.Equal(Environment.GetEnvironmentVariable("IP"), "127.0.0.1");
             Assert.Equal(Environment.GetEnvironmentVariable("PORT"), "8080");
             Assert.Equal(Environment.GetEnvironmentVariable("DOMAIN"), "example.com");
+            Assert.Equal(Environment.GetEnvironmentVariable("EMBEDEXPORT"), "some text export other text");
+            Assert.Equal(Environment.GetEnvironmentVariable("COMMENTLEAD"), null);
+            Assert.Equal(Environment.GetEnvironmentVariable("WHITELEAD"), "leading white space followed by comment");
+        }
+
+        [Fact]
+        public void LoadArgsTest()
+        {
+            DotNetEnv.Env.Load(true);
+            Assert.Equal(Environment.GetEnvironmentVariable("WHITEBOTH"), "leading and trailing white space");
+            DotNetEnv.Env.Load(false);
+            Assert.Equal(Environment.GetEnvironmentVariable("  WHITEBOTH  "), "  leading and trailing white space   ");
+            DotNetEnv.Env.Load(true, true);
+            Assert.Equal(Environment.GetEnvironmentVariable("PASSWORD"), "Google");
+            DotNetEnv.Env.Load(true, false);
+            Assert.Equal(Environment.GetEnvironmentVariable("PASSWORD"), "Google#Facebook");
+        }
+
+        [Fact]
+        public void LoadPathArgsTest()
+        {
+            DotNetEnv.Env.Load("./.env2", true, true);
+            Assert.Equal(Environment.GetEnvironmentVariable("WHITELEAD"), "leading white space followed by comment");
+            DotNetEnv.Env.Load("./.env2", false, true);
+            Assert.Equal(Environment.GetEnvironmentVariable("WHITELEAD"), "  leading white space followed by comment  ");
+            DotNetEnv.Env.Load("./.env2", true, false);
+            Assert.Equal(Environment.GetEnvironmentVariable("WHITELEAD"), "leading white space followed by comment  # comment");
+            DotNetEnv.Env.Load("./.env2", false, false);
+            Assert.Equal(Environment.GetEnvironmentVariable("WHITELEAD"), "  leading white space followed by comment  # comment");
         }
     }
 }


### PR DESCRIPTION
replaces both https://github.com/tonerdo/dotnet-env/pull/6 and https://github.com/tonerdo/dotnet-env/pull/5