### PR TITLE
add clobber option to load function

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,18 @@ False would mean:
 "\"quoted\\n\\tvalue\"" == System.Environment.GetEnvironmentVariable("KEY")
 ```
 
+4. `clobberExistingVars`, fourth arg: false to avoid overwriting existing environment variables
+
+```env
+KEY=value
+```
+
+```csharp
+System.Environment.SetEnvironmentVariable("KEY", "really important value, don't overwrite");
+DotNetEnv.Env.Load(false, false, false, false); // fourth arg false, don't overwrite existing variables
+System.Environment.GetEnvironmentVariable("KEY"); // == "really important value, don't overwrite"
+```
+
 ## Issue Reporting
 
 If you have found a bug or if you have a feature request, please report them at this repository issues section.

--- a/src/DotNetEnv/Env.cs
+++ b/src/DotNetEnv/Env.cs
@@ -8,7 +8,8 @@ namespace DotNetEnv
             string path,
             bool trimWhitespace = true,
             bool isEmbeddedHashComment = true,
-            bool unescapeQuotedValues = true
+            bool unescapeQuotedValues = true,
+            bool clobberExistingVars = true
         )
         {
             Vars envFile = Parser.Parse(
@@ -17,19 +18,21 @@ namespace DotNetEnv
                 isEmbeddedHashComment,
                 unescapeQuotedValues
             );
-            LoadVars.SetEnvironmentVariables(envFile);
+            LoadVars.SetEnvironmentVariables(envFile, clobberExistingVars);
         }
 
         public static void Load(
             bool trimWhitespace = true,
             bool isEmbeddedHashComment = true,
-            bool unescapeQuotedValues = true
+            bool unescapeQuotedValues = true,
+            bool clobberExistingVars = true
         )
         => Load(
             Path.Combine(Directory.GetCurrentDirectory(), ".env"),
             trimWhitespace,
             isEmbeddedHashComment,
-            unescapeQuotedValues
+            unescapeQuotedValues,
+            clobberExistingVars
         );
     }
 }

--- a/src/DotNetEnv/LoadVars.cs
+++ b/src/DotNetEnv/LoadVars.cs
@@ -1,14 +1,20 @@
 using System;
+using System.Collections;
 
 namespace DotNetEnv
 {
     internal class LoadVars
     {
-        public static void SetEnvironmentVariables(Vars vars)
+        public static void SetEnvironmentVariables(Vars vars, bool clobberExistingVars = true)
         {
+            IDictionary currentVars = null;
+            if (!clobberExistingVars)
+                currentVars = Environment.GetEnvironmentVariables();
+                
             foreach (var keyValuePair in vars)
             {
-                Environment.SetEnvironmentVariable(keyValuePair.Key, keyValuePair.Value);
+                if (clobberExistingVars || !currentVars.Contains(keyValuePair.Key))
+                    Environment.SetEnvironmentVariable(keyValuePair.Key, keyValuePair.Value);
             }
         }
     }

--- a/test/DotNetEnv.Tests/EnvTests.cs
+++ b/test/DotNetEnv.Tests/EnvTests.cs
@@ -62,5 +62,18 @@ namespace DotNetEnv.Tests
             DotNetEnv.Env.Load("./.env2", false, false, false);
             Assert.Equal(Environment.GetEnvironmentVariable("UNICODE"), "'\\u00ae \\U0001F680 日本'");
         }
+
+        [Fact]
+        public void LoadNoClobberTest()
+        {
+            var expected = "totally the original value";
+            Environment.SetEnvironmentVariable("URL", expected);
+            DotNetEnv.Env.Load(false, false, false, false);
+            Assert.Equal(Environment.GetEnvironmentVariable("URL"), expected);
+
+            Environment.SetEnvironmentVariable("URL", "i'm going to be overwritten");
+            DotNetEnv.Env.Load(false, false, false, true);
+            Assert.Equal(Environment.GetEnvironmentVariable("URL"), "https://github.com/tonerdo");
+        }
     }
 }


### PR DESCRIPTION
Default behavior is to set all environment variables in dotenv file. This would make it possible to not overwrite existing variables.