### PR TITLE
use netstandard1.3 instead of 2.0 to support as far back as .NET env …

### DIFF
--- a/src/DotNetEnv/DotNetEnv.csproj
+++ b/src/DotNetEnv/DotNetEnv.csproj
@@ -4,7 +4,7 @@
     <Description>A .NET library to load environment variables from .env files</Description>
     <AssemblyTitle>DotNetEnv</AssemblyTitle>
     <PackageVersion>1.1.0</PackageVersion>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
     <AssemblyName>DotNetEnv</AssemblyName>
     <OutputType>Library</OutputType>
     <PackageId>DotNetEnv</PackageId>


### PR DESCRIPTION
…var support exists