### PR TITLE
Clobber using platform case-sensitivity rule

### DIFF
--- a/src/DotNetEnv/LoadVars.cs
+++ b/src/DotNetEnv/LoadVars.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 
 namespace DotNetEnv
 {
@@ -7,13 +6,9 @@ namespace DotNetEnv
     {
         public static void SetEnvironmentVariables(Vars vars, bool clobberExistingVars = true)
         {
-            IDictionary currentVars = null;
-            if (!clobberExistingVars)
-                currentVars = Environment.GetEnvironmentVariables();
-                
             foreach (var keyValuePair in vars)
             {
-                if (clobberExistingVars || !currentVars.Contains(keyValuePair.Key))
+                if (clobberExistingVars || Environment.GetEnvironmentVariable(keyValuePair.Key) == null)
                     Environment.SetEnvironmentVariable(keyValuePair.Key, keyValuePair.Value);
             }
         }

--- a/test/DotNetEnv.Tests/.env3
+++ b/test/DotNetEnv.Tests/.env3
@@ -1,0 +1,1 @@
+casing=lower

--- a/test/DotNetEnv.Tests/DotNetEnv.Tests.csproj
+++ b/test/DotNetEnv.Tests/DotNetEnv.Tests.csproj
@@ -14,6 +14,9 @@
     <None Include="./.env2">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="./.env3">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/DotNetEnv.Tests/EnvTests.cs
+++ b/test/DotNetEnv.Tests/EnvTests.cs
@@ -1,50 +1,12 @@
 ﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.InteropServices;
 using Xunit;
 
 namespace DotNetEnv.Tests
 {
-    public class EnvTests : IDisposable
+    public class EnvTests
     {
-        readonly IDictionary<string, string> _oldEnvironment;
-
-        static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-
-        /// <summary>
-        /// Saves the environment before each test is run.
-        /// </summary>
-
-        public EnvTests() =>
-            _oldEnvironment =
-                Environment.GetEnvironmentVariables()
-                           .Cast<DictionaryEntry>()
-                           .ToDictionary(e => e.Key.ToString(),
-                                         e => e.Value.ToString());
-
-        /// <summary>
-        /// Resets the environment after each test is run.
-        /// </summary>
-
-        public void Dispose()
-        {
-            foreach (var var in _oldEnvironment)
-                Environment.SetEnvironmentVariable(var.Key, var.Value);
-
-            var comparer = IsWindows
-                         ? StringComparer.OrdinalIgnoreCase
-                         : StringComparer.Ordinal;
-
-            var newNames = Environment.GetEnvironmentVariables().Keys
-                                      .Cast<string>()
-                                      .Except(_oldEnvironment.Keys,
-                                              comparer);
-
-            foreach (var name in newNames)
-                Environment.SetEnvironmentVariable(name, null);
-        }
+        private static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
         [Fact]
         public void LoadTest()
@@ -104,22 +66,40 @@ namespace DotNetEnv.Tests
             Assert.Equal(Environment.GetEnvironmentVariable("UNICODE"), "'\\u00ae \\U0001F680 日本'");
         }
 
-        [Theory]
-        [InlineData("URL", "URL")]
-        [InlineData("url", "URL")]
-        public void LoadNoClobberTest(string setName, string getName)
+        [Fact]
+        public void LoadNoClobberTest()
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                setName = getName;
-
             var expected = "totally the original value";
-            Environment.SetEnvironmentVariable(setName, expected);
+            Environment.SetEnvironmentVariable("URL", expected);
             DotNetEnv.Env.Load(false, false, false, false);
-            Assert.Equal(Environment.GetEnvironmentVariable(getName), expected);
+            Assert.Equal(Environment.GetEnvironmentVariable("URL"), expected);
 
-            Environment.SetEnvironmentVariable(setName, "i'm going to be overwritten");
+            Environment.SetEnvironmentVariable("URL", "i'm going to be overwritten");
             DotNetEnv.Env.Load(false, false, false, true);
-            Assert.Equal(Environment.GetEnvironmentVariable(getName), "https://github.com/tonerdo");
+            Assert.Equal(Environment.GetEnvironmentVariable("URL"), "https://github.com/tonerdo");
+        }
+
+        [Fact]
+        public void LoadOsCasingTest()
+        {
+            Environment.SetEnvironmentVariable("CASING", "neither");
+            DotNetEnv.Env.Load("./.env3", clobberExistingVars: false);
+            Assert.Equal(Environment.GetEnvironmentVariable("casing"), IsWindows ? "neither" : "lower");
+            Assert.Equal(Environment.GetEnvironmentVariable("CASING"), "neither");
+
+            DotNetEnv.Env.Load("./.env3", clobberExistingVars: true);
+            Assert.Equal(Environment.GetEnvironmentVariable("casing"), "lower");
+            Assert.Equal(Environment.GetEnvironmentVariable("CASING"), IsWindows ? "lower" : "neither");
+
+            Environment.SetEnvironmentVariable("CASING", null);
+            Environment.SetEnvironmentVariable("casing", "neither");
+            DotNetEnv.Env.Load("./.env3", clobberExistingVars: false);
+            Assert.Equal(Environment.GetEnvironmentVariable("casing"), "neither");
+            Assert.Equal(Environment.GetEnvironmentVariable("CASING"), IsWindows ? "neither" : null);
+
+            DotNetEnv.Env.Load("./.env3", clobberExistingVars: true);
+            Assert.Equal(Environment.GetEnvironmentVariable("casing"), "lower");
+            Assert.Equal(Environment.GetEnvironmentVariable("CASING"), IsWindows ? "lower" : null);
         }
     }
 }

--- a/test/DotNetEnv.Tests/EnvTests.cs
+++ b/test/DotNetEnv.Tests/EnvTests.cs
@@ -1,10 +1,51 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace DotNetEnv.Tests
 {
-    public class EnvTests
+    public class EnvTests : IDisposable
     {
+        readonly IDictionary<string, string> _oldEnvironment;
+
+        static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+        /// <summary>
+        /// Saves the environment before each test is run.
+        /// </summary>
+
+        public EnvTests() =>
+            _oldEnvironment =
+                Environment.GetEnvironmentVariables()
+                           .Cast<DictionaryEntry>()
+                           .ToDictionary(e => e.Key.ToString(),
+                                         e => e.Value.ToString());
+
+        /// <summary>
+        /// Resets the environment after each test is run.
+        /// </summary>
+
+        public void Dispose()
+        {
+            foreach (var var in _oldEnvironment)
+                Environment.SetEnvironmentVariable(var.Key, var.Value);
+
+            var comparer = IsWindows
+                         ? StringComparer.OrdinalIgnoreCase
+                         : StringComparer.Ordinal;
+
+            var newNames = Environment.GetEnvironmentVariables().Keys
+                                      .Cast<string>()
+                                      .Except(_oldEnvironment.Keys,
+                                              comparer);
+
+            foreach (var name in newNames)
+                Environment.SetEnvironmentVariable(name, null);
+        }
+
         [Fact]
         public void LoadTest()
         {
@@ -63,17 +104,22 @@ namespace DotNetEnv.Tests
             Assert.Equal(Environment.GetEnvironmentVariable("UNICODE"), "'\\u00ae \\U0001F680 日本'");
         }
 
-        [Fact]
-        public void LoadNoClobberTest()
+        [Theory]
+        [InlineData("URL", "URL")]
+        [InlineData("url", "URL")]
+        public void LoadNoClobberTest(string setName, string getName)
         {
-            var expected = "totally the original value";
-            Environment.SetEnvironmentVariable("URL", expected);
-            DotNetEnv.Env.Load(false, false, false, false);
-            Assert.Equal(Environment.GetEnvironmentVariable("URL"), expected);
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                setName = getName;
 
-            Environment.SetEnvironmentVariable("URL", "i'm going to be overwritten");
+            var expected = "totally the original value";
+            Environment.SetEnvironmentVariable(setName, expected);
+            DotNetEnv.Env.Load(false, false, false, false);
+            Assert.Equal(Environment.GetEnvironmentVariable(getName), expected);
+
+            Environment.SetEnvironmentVariable(setName, "i'm going to be overwritten");
             DotNetEnv.Env.Load(false, false, false, true);
-            Assert.Equal(Environment.GetEnvironmentVariable("URL"), "https://github.com/tonerdo");
+            Assert.Equal(Environment.GetEnvironmentVariable(getName), "https://github.com/tonerdo");
         }
     }
 }


### PR DESCRIPTION
On Windows, environment names are case-insensitive whereas on Unix-like systems they are case-sensitive. When clobbering, use the rules of the platform to determine if an environment variable should be clobbered or not.

This PR includes tests to test case-insensitivity of environment names on Windows. I had to also add test setup and tear-down code to make them deterministic.