### PR TITLE
Add LoadOptions parameter to clean up options handling in Env

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,19 @@ DotNetEnv.Env.GetString("THIS_DOES_NOT_EXIST", "Variable not found");
 
 ### Additional arguments
 
-You can also control whitespace trimming and allowing hashes in values
+You can also pass a LoadOptions object arg to all DotNetEnv.Env.Load variants to affect the Load/Parse behavior:
+
 ```csharp
-DotNetEnv.Env.Load(false, false);
+new DotNetEnv.Env.LoadOptions(
+    trimWhitespace: false,
+    isEmbeddedHashComment: false,
+    unescapeQuotedValues: false,
+    clobberExistingVars: false
+)
 ```
 
-Both parameters default to true, which means:
+All parameters default to true, which means:
+
 1. `trimWhitespace`, first arg: true in order to trim
  leading and trailing whitespace from keys and values such that
 
@@ -145,13 +152,25 @@ KEY=value
 
 ```csharp
 System.Environment.SetEnvironmentVariable("KEY", "really important value, don't overwrite");
-DotNetEnv.Env.Load(false, false, false, false); // fourth arg false, don't overwrite existing variables
-System.Environment.GetEnvironmentVariable("KEY"); // == "really important value, don't overwrite"
+DotNetEnv.Env.Load(
+    new DotNetEnv.Env.LoadOptions(
+        clobberExistingVars: false
+    )
+)
+"really important value, don't overwrite" == System.Environment.GetEnvironmentVariable("KEY")  // not "value" from the .env file
 ```
 
 ## Issue Reporting
 
 If you have found a bug or if you have a feature request, please report them at this repository issues section.
+
+## Contributing
+
+Run `dotnet test test/DotNetEnv.Tests` to run all tests.
+
+`src/DotNetEnvEnv/Env.cs` is the entry point for all behavior.
+
+Open a PR on Github if you have some changes, or an issue if you want to discuss some proposed changes before creating a PR for them.
 
 ## License
 

--- a/src/DotNetEnv/Env.cs
+++ b/src/DotNetEnv/Env.cs
@@ -7,45 +7,23 @@ namespace DotNetEnv
 {
     public class Env
     {
-        public static void Load(
-            string[] lines,
-            bool trimWhitespace = true,
-            bool isEmbeddedHashComment = true,
-            bool unescapeQuotedValues = true,
-            bool clobberExistingVars = true
-        )
+        public static void Load(string[] lines, LoadOptions options)
         {
             Vars envFile = Parser.Parse(
                 lines,
-                trimWhitespace,
-                isEmbeddedHashComment,
-                unescapeQuotedValues
+                options.TrimWhitespace,
+                options.IsEmbeddedHashComment,
+                options.UnescapeQuotedValues
             );
-            LoadVars.SetEnvironmentVariables(envFile, clobberExistingVars);
+            LoadVars.SetEnvironmentVariables(envFile, options.ClobberExistingVars);
         }
-        
-        public static void Load(
-            string path,
-            bool trimWhitespace = true,
-            bool isEmbeddedHashComment = true,
-            bool unescapeQuotedValues = true,
-            bool clobberExistingVars = true
-        )
-        => Load(
-            File.ReadAllLines(path),
-            trimWhitespace,
-            isEmbeddedHashComment,
-            unescapeQuotedValues,
-            clobberExistingVars
-        );
 
-        public static void Load(
-            Stream file,
-            bool trimWhitespace = true,
-            bool isEmbeddedHashComment = true,
-            bool unescapeQuotedValues = true,
-            bool clobberExistingVars = true
-        )
+        public static void Load(string path, LoadOptions options)
+        {
+            Load(File.ReadAllLines(path), options);
+        }
+
+        public static void Load(Stream file, LoadOptions options)
         {
             var lines = new List<string>();
             var currentLine = "";
@@ -57,15 +35,81 @@ namespace DotNetEnv
                     if (currentLine != null) lines.Add(currentLine);
                 }
             }
-            Load(
-                lines.ToArray(),
+            Load(lines.ToArray(), options);
+        }
+
+        public static void Load(LoadOptions options)
+        => Load(Path.Combine(Directory.GetCurrentDirectory(), ".env"), options);
+
+        public static string GetString(string key, string fallback = default(string)) =>
+            Environment.GetEnvironmentVariable(key) ?? fallback;
+
+        public static bool GetBool(string key, bool fallback = default(bool)) =>
+            bool.TryParse(Environment.GetEnvironmentVariable(key), out var value) ? value : fallback;
+
+        public static int GetInt(string key, int fallback = default(int)) =>
+            int.TryParse(Environment.GetEnvironmentVariable(key), out var value) ? value : fallback;
+
+        public static double GetDouble(string key, double fallback = default(double)) =>
+            double.TryParse(Environment.GetEnvironmentVariable(key), NumberStyles.Any, CultureInfo.InvariantCulture, out var value) ? value : fallback;
+
+        #region "Obsolete parameters list"
+
+        [Obsolete("list of flag arguments is deprecated, use the options object")]
+        public static void Load(
+            string[] lines,
+            bool trimWhitespace = true,
+            bool isEmbeddedHashComment = true,
+            bool unescapeQuotedValues = true,
+            bool clobberExistingVars = true
+        )
+        => Load(
+            lines,
+            new LoadOptions(
                 trimWhitespace,
                 isEmbeddedHashComment,
                 unescapeQuotedValues,
                 clobberExistingVars
-            );
-        }
+            )
+        );
+        
+        [Obsolete("list of flag arguments is deprecated, use the options object")]
+        public static void Load(
+            string path,
+            bool trimWhitespace = true,
+            bool isEmbeddedHashComment = true,
+            bool unescapeQuotedValues = true,
+            bool clobberExistingVars = true
+        )
+        => Load(
+            path,
+            new LoadOptions(
+                trimWhitespace,
+                isEmbeddedHashComment,
+                unescapeQuotedValues,
+                clobberExistingVars
+            )
+        );
 
+        [Obsolete("list of flag arguments is deprecated, use the options object")]
+        public static void Load(
+            Stream file,
+            bool trimWhitespace = true,
+            bool isEmbeddedHashComment = true,
+            bool unescapeQuotedValues = true,
+            bool clobberExistingVars = true
+        )
+        => Load(
+            file,
+            new LoadOptions(
+                trimWhitespace,
+                isEmbeddedHashComment,
+                unescapeQuotedValues,
+                clobberExistingVars
+            )
+        );
+
+        [Obsolete("list of flag arguments is deprecated, use the options object")]
         public static void Load(
             bool trimWhitespace = true,
             bool isEmbeddedHashComment = true,
@@ -73,23 +117,35 @@ namespace DotNetEnv
             bool clobberExistingVars = true
         )
         => Load(
-            Path.Combine(Directory.GetCurrentDirectory(), ".env"),
-            trimWhitespace,
-            isEmbeddedHashComment,
-            unescapeQuotedValues,
-            clobberExistingVars
+            new LoadOptions(
+                trimWhitespace,
+                isEmbeddedHashComment,
+                unescapeQuotedValues,
+                clobberExistingVars
+            )
         );
-        
-        public static string GetString(string key, string fallback = default(string)) =>
-            Environment.GetEnvironmentVariable(key) ?? fallback;
-        
-        public static bool GetBool(string key, bool fallback = default(bool)) => 
-            bool.TryParse(Environment.GetEnvironmentVariable(key), out var value) ? value : fallback;
-        
-        public static int GetInt(string key, int fallback = default(int)) =>
-         int.TryParse(Environment.GetEnvironmentVariable(key), out var value) ? value : fallback;
-        
-        public static double GetDouble(string key, double fallback = default(double)) =>
-         double.TryParse(Environment.GetEnvironmentVariable(key), NumberStyles.Any, CultureInfo.InvariantCulture, out var value) ? value : fallback;
+
+        #endregion
+
+        public class LoadOptions
+        {
+            public bool TrimWhitespace { get; }
+            public bool IsEmbeddedHashComment { get; }
+            public bool UnescapeQuotedValues { get; }
+            public bool ClobberExistingVars { get; }
+
+            public LoadOptions(
+                bool trimWhitespace = true,
+                bool isEmbeddedHashComment = true,
+                bool unescapeQuotedValues = true,
+                bool clobberExistingVars = true
+            )
+            {
+                TrimWhitespace = trimWhitespace;
+                IsEmbeddedHashComment = isEmbeddedHashComment;
+                UnescapeQuotedValues = unescapeQuotedValues;
+                ClobberExistingVars = clobberExistingVars;
+            }
+        }
     }
 }

--- a/test/DotNetEnv.Tests/EnvTests.cs
+++ b/test/DotNetEnv.Tests/EnvTests.cs
@@ -70,6 +70,78 @@ namespace DotNetEnv.Tests
         [Fact]
         public void LoadArgsTest()
         {
+            DotNetEnv.Env.Load(new DotNetEnv.Env.LoadOptions(true));
+            Assert.Equal(Environment.GetEnvironmentVariable("WHITEBOTH"), "leading and trailing white space");
+            DotNetEnv.Env.Load(new DotNetEnv.Env.LoadOptions(false));
+            Assert.Equal(Environment.GetEnvironmentVariable("  WHITEBOTH  "), "  leading and trailing white space   ");
+            DotNetEnv.Env.Load(new DotNetEnv.Env.LoadOptions(true, true));
+            Assert.Equal(Environment.GetEnvironmentVariable("PASSWORD"), "Google");
+            DotNetEnv.Env.Load(new DotNetEnv.Env.LoadOptions(true, false));
+            Assert.Equal(Environment.GetEnvironmentVariable("PASSWORD"), "Google#Facebook");
+            DotNetEnv.Env.Load(new DotNetEnv.Env.LoadOptions(true, true, true));
+            Assert.Equal(Environment.GetEnvironmentVariable("SSL_CERT"), "SPECIAL STUFF---\nLONG-BASE64\\ignore\"slash");
+            DotNetEnv.Env.Load(new DotNetEnv.Env.LoadOptions(true, true, false));
+            Assert.Equal(Environment.GetEnvironmentVariable("SSL_CERT"), "\"SPECIAL STUFF---\\nLONG-BASE64\\ignore\"slash\"");
+        }
+
+        [Fact]
+        public void LoadPathArgsTest()
+        {
+            DotNetEnv.Env.Load("./.env2", new DotNetEnv.Env.LoadOptions(true, true));
+            Assert.Equal(Environment.GetEnvironmentVariable("WHITELEAD"), "leading white space followed by comment");
+            DotNetEnv.Env.Load("./.env2", new DotNetEnv.Env.LoadOptions(false, true));
+            Assert.Equal(Environment.GetEnvironmentVariable("WHITELEAD"), "  leading white space followed by comment  ");
+            DotNetEnv.Env.Load("./.env2", new DotNetEnv.Env.LoadOptions(true, false));
+            Assert.Equal(Environment.GetEnvironmentVariable("WHITELEAD"), "leading white space followed by comment  # comment");
+            DotNetEnv.Env.Load("./.env2", new DotNetEnv.Env.LoadOptions(false, false));
+            Assert.Equal(Environment.GetEnvironmentVariable("WHITELEAD"), "  leading white space followed by comment  # comment");
+            DotNetEnv.Env.Load("./.env2", new DotNetEnv.Env.LoadOptions(false, false, true));
+            Assert.Equal(Environment.GetEnvironmentVariable("UNICODE"), "® 🚀 日本");
+            DotNetEnv.Env.Load("./.env2", new DotNetEnv.Env.LoadOptions(false, false, false));
+            Assert.Equal(Environment.GetEnvironmentVariable("UNICODE"), "'\\u00ae \\U0001F680 日本'");
+        }
+
+        [Fact]
+        public void LoadNoClobberTest()
+        {
+            var expected = "totally the original value";
+            Environment.SetEnvironmentVariable("URL", expected);
+            DotNetEnv.Env.Load(new DotNetEnv.Env.LoadOptions(false, false, false, false));
+            Assert.Equal(Environment.GetEnvironmentVariable("URL"), expected);
+
+            Environment.SetEnvironmentVariable("URL", "i'm going to be overwritten");
+            DotNetEnv.Env.Load(new DotNetEnv.Env.LoadOptions(false, false, false, true));
+            Assert.Equal(Environment.GetEnvironmentVariable("URL"), "https://github.com/tonerdo");
+        }
+
+        [Fact]
+        public void LoadOsCasingTest()
+        {
+            Environment.SetEnvironmentVariable("CASING", "neither");
+            DotNetEnv.Env.Load("./.env3", new DotNetEnv.Env.LoadOptions(clobberExistingVars: false));
+            Assert.Equal(Environment.GetEnvironmentVariable("casing"), IsWindows ? "neither" : "lower");
+            Assert.Equal(Environment.GetEnvironmentVariable("CASING"), "neither");
+
+            DotNetEnv.Env.Load("./.env3", new DotNetEnv.Env.LoadOptions(clobberExistingVars: true));
+            Assert.Equal(Environment.GetEnvironmentVariable("casing"), "lower");
+            Assert.Equal(Environment.GetEnvironmentVariable("CASING"), IsWindows ? "lower" : "neither");
+
+            Environment.SetEnvironmentVariable("CASING", null);
+            Environment.SetEnvironmentVariable("casing", "neither");
+            DotNetEnv.Env.Load("./.env3", new DotNetEnv.Env.LoadOptions(clobberExistingVars: false));
+            Assert.Equal(Environment.GetEnvironmentVariable("casing"), "neither");
+            Assert.Equal(Environment.GetEnvironmentVariable("CASING"), IsWindows ? "neither" : null);
+
+            DotNetEnv.Env.Load("./.env3", new DotNetEnv.Env.LoadOptions(clobberExistingVars: true));
+            Assert.Equal(Environment.GetEnvironmentVariable("casing"), "lower");
+            Assert.Equal(Environment.GetEnvironmentVariable("CASING"), IsWindows ? "lower" : null);
+        }
+
+        #region "Obsolete parameters list"
+
+        [Fact]
+        public void ObsoleteLoadArgsTest()
+        {
             DotNetEnv.Env.Load(true);
             Assert.Equal(Environment.GetEnvironmentVariable("WHITEBOTH"), "leading and trailing white space");
             DotNetEnv.Env.Load(false);
@@ -85,7 +157,7 @@ namespace DotNetEnv.Tests
         }
 
         [Fact]
-        public void LoadPathArgsTest()
+        public void ObsoleteLoadPathArgsTest()
         {
             DotNetEnv.Env.Load("./.env2", true, true);
             Assert.Equal(Environment.GetEnvironmentVariable("WHITELEAD"), "leading white space followed by comment");
@@ -102,7 +174,7 @@ namespace DotNetEnv.Tests
         }
 
         [Fact]
-        public void LoadNoClobberTest()
+        public void ObsoleteLoadNoClobberTest()
         {
             var expected = "totally the original value";
             Environment.SetEnvironmentVariable("URL", expected);
@@ -115,7 +187,7 @@ namespace DotNetEnv.Tests
         }
 
         [Fact]
-        public void LoadOsCasingTest()
+        public void ObsoleteLoadOsCasingTest()
         {
             Environment.SetEnvironmentVariable("CASING", "neither");
             DotNetEnv.Env.Load("./.env3", clobberExistingVars: false);
@@ -136,5 +208,7 @@ namespace DotNetEnv.Tests
             Assert.Equal(Environment.GetEnvironmentVariable("casing"), "lower");
             Assert.Equal(Environment.GetEnvironmentVariable("CASING"), IsWindows ? "lower" : null);
         }
+
+        #endregion
     }
 }


### PR DESCRIPTION
I'm going to add a new parameter in a subsequent PR, want to keep those changes separate tho:
https://github.com/rogusdev/dotnet-env/pull/1/files (will create that PR against this repo once this PR is merged)