### PR TITLE
Moved default ".env" to public constant so it is accessible externally

### DIFF
--- a/src/DotNetEnv/Env.cs
+++ b/src/DotNetEnv/Env.cs
@@ -7,6 +7,9 @@ namespace DotNetEnv
 {
     public class Env
     {
+
+        public const string DEFAULT_ENVFILENAME = ".env";
+
         public static void Load(string[] lines, LoadOptions options)
         {
             Vars envFile = Parser.Parse(
@@ -40,7 +43,7 @@ namespace DotNetEnv
         }
 
         public static void Load(LoadOptions options)
-        => Load(Path.Combine(Directory.GetCurrentDirectory(), ".env"), options);
+        => Load(Path.Combine(Directory.GetCurrentDirectory(), DEFAULT_ENVFILENAME), options);
 
         public static string GetString(string key, string fallback = default(string)) =>
             Environment.GetEnvironmentVariable(key) ?? fallback;

--- a/src/DotNetEnv/Env.cs
+++ b/src/DotNetEnv/Env.cs
@@ -7,7 +7,6 @@ namespace DotNetEnv
 {
     public class Env
     {
-
         public const string DEFAULT_ENVFILENAME = ".env";
 
         public static void Load(string[] lines, LoadOptions options)


### PR DESCRIPTION
When using the library with a combination of web apps and command line apps I found myself defining the ".env" string multiple times.  Since this is the standard convention, this PR just moves the ".env" name to a public const so apps can us it instead of defining.

