### PR TITLE
make a lot of backwards incompatible changes

### DIFF
--- a/src/DotNetEnv/DotNetEnv.csproj
+++ b/src/DotNetEnv/DotNetEnv.csproj
@@ -3,8 +3,8 @@
     <Title>DotNetEnv</Title>
     <Description>A .NET library to load environment variables from .env files</Description>
     <AssemblyTitle>DotNetEnv</AssemblyTitle>
-    <AssemblyVersion>1.3.1</AssemblyVersion>
-    <PackageVersion>1.3.1</PackageVersion>
+    <AssemblyVersion>1.4.0</AssemblyVersion>
+    <PackageVersion>1.4.0</PackageVersion>
     <TargetFramework>netstandard1.3</TargetFramework>
     <AssemblyName>DotNetEnv</AssemblyName>
     <OutputType>Library</OutputType>

--- a/src/DotNetEnv/Env.cs
+++ b/src/DotNetEnv/Env.cs
@@ -9,8 +9,12 @@ namespace DotNetEnv
     {
         public const string DEFAULT_ENVFILENAME = ".env";
 
-        public static void Load(string[] lines, LoadOptions options)
+        private static LoadOptions DEFAULT_OPTIONS = new LoadOptions();
+
+        public static void Load(string[] lines, LoadOptions options = null)
         {
+            if (options == null) options = DEFAULT_OPTIONS;
+
             Vars envFile = Parser.Parse(
                 lines,
                 options.TrimWhitespace,
@@ -21,13 +25,13 @@ namespace DotNetEnv
             LoadVars.SetEnvironmentVariables(envFile, options.ClobberExistingVars);
         }
 
-        public static void Load(string path, LoadOptions options)
+        public static void Load(string path, LoadOptions options = null)
         {
-            if (!options.RequireEnvFile && !File.Exists(path)) return;
+            if (!File.Exists(path)) return;
             Load(File.ReadAllLines(path), options);
         }
 
-        public static void Load(Stream file, LoadOptions options)
+        public static void Load(Stream file, LoadOptions options = null)
         {
             var lines = new List<string>();
             var currentLine = "";
@@ -42,7 +46,7 @@ namespace DotNetEnv
             Load(lines.ToArray(), options);
         }
 
-        public static void Load(LoadOptions options) =>
+        public static void Load(LoadOptions options = null) =>
             Load(Path.Combine(Directory.GetCurrentDirectory(), DEFAULT_ENVFILENAME), options);
 
         public static string GetString(string key, string fallback = default(string)) =>
@@ -57,87 +61,12 @@ namespace DotNetEnv
         public static double GetDouble(string key, double fallback = default(double)) =>
             double.TryParse(Environment.GetEnvironmentVariable(key), NumberStyles.Any, CultureInfo.InvariantCulture, out var value) ? value : fallback;
 
-        #region "Obsolete parameters list"
-
-        [Obsolete("list of flag arguments is deprecated, use the options object")]
-        public static void Load(
-            string[] lines,
-            bool trimWhitespace = true,
-            bool isEmbeddedHashComment = true,
-            bool unescapeQuotedValues = true,
-            bool clobberExistingVars = true
-        )
-        => Load(
-            lines,
-            new LoadOptions(
-                trimWhitespace,
-                isEmbeddedHashComment,
-                unescapeQuotedValues,
-                clobberExistingVars
-            )
-        );
-        
-        [Obsolete("list of flag arguments is deprecated, use the options object")]
-        public static void Load(
-            string path,
-            bool trimWhitespace = true,
-            bool isEmbeddedHashComment = true,
-            bool unescapeQuotedValues = true,
-            bool clobberExistingVars = true
-        )
-        => Load(
-            path,
-            new LoadOptions(
-                trimWhitespace,
-                isEmbeddedHashComment,
-                unescapeQuotedValues,
-                clobberExistingVars
-            )
-        );
-
-        [Obsolete("list of flag arguments is deprecated, use the options object")]
-        public static void Load(
-            Stream file,
-            bool trimWhitespace = true,
-            bool isEmbeddedHashComment = true,
-            bool unescapeQuotedValues = true,
-            bool clobberExistingVars = true
-        )
-        => Load(
-            file,
-            new LoadOptions(
-                trimWhitespace,
-                isEmbeddedHashComment,
-                unescapeQuotedValues,
-                clobberExistingVars
-            )
-        );
-
-        [Obsolete("list of flag arguments is deprecated, use the options object")]
-        public static void Load(
-            bool trimWhitespace = true,
-            bool isEmbeddedHashComment = true,
-            bool unescapeQuotedValues = true,
-            bool clobberExistingVars = true
-        )
-        => Load(
-            new LoadOptions(
-                trimWhitespace,
-                isEmbeddedHashComment,
-                unescapeQuotedValues,
-                clobberExistingVars
-            )
-        );
-
-        #endregion
-
         public class LoadOptions
         {
             public bool TrimWhitespace { get; }
             public bool IsEmbeddedHashComment { get; }
             public bool UnescapeQuotedValues { get; }
             public bool ClobberExistingVars { get; }
-            public bool RequireEnvFile { get; }
             public bool ParseVariables { get; }
 
             public LoadOptions(
@@ -145,7 +74,6 @@ namespace DotNetEnv
                 bool isEmbeddedHashComment = true,
                 bool unescapeQuotedValues = true,
                 bool clobberExistingVars = true,
-                bool requireEnvFile = true,
                 bool parseVariables = true
             )
             {
@@ -153,7 +81,6 @@ namespace DotNetEnv
                 IsEmbeddedHashComment = isEmbeddedHashComment;
                 UnescapeQuotedValues = unescapeQuotedValues;
                 ClobberExistingVars = clobberExistingVars;
-                RequireEnvFile = requireEnvFile;
                 ParseVariables = parseVariables;
             }
         }

--- a/test/DotNetEnv.Tests/EnvTests.cs
+++ b/test/DotNetEnv.Tests/EnvTests.cs
@@ -120,11 +120,7 @@ namespace DotNetEnv.Tests
             var expected = "totally the original value";
             Environment.SetEnvironmentVariable("URL", expected);
             // this env file Does Not Exist
-            DotNetEnv.Env.Load("./.envDNE",
-                new DotNetEnv.Env.LoadOptions(
-                    requireEnvFile: false
-                )
-            );
+            DotNetEnv.Env.Load("./.envDNE", new DotNetEnv.Env.LoadOptions());
             Assert.Equal(Environment.GetEnvironmentVariable("URL"), expected);
             // it didn't throw an exception and crash for a missing file
         }
@@ -163,79 +159,5 @@ namespace DotNetEnv.Tests
             Assert.Equal(Environment.GetEnvironmentVariable("TEST4"), "testtest1");
             Assert.Equal(Environment.GetEnvironmentVariable("TEST5"), "test:testtest1 and test1");
         }
-
-        #region "Obsolete parameters list"
-
-        [Fact]
-        public void ObsoleteLoadArgsTest()
-        {
-            DotNetEnv.Env.Load(true);
-            Assert.Equal(Environment.GetEnvironmentVariable("WHITEBOTH"), "leading and trailing white space");
-            DotNetEnv.Env.Load(false);
-            Assert.Equal(Environment.GetEnvironmentVariable("  WHITEBOTH  "), "  leading and trailing white space   ");
-            DotNetEnv.Env.Load(true, true);
-            Assert.Equal(Environment.GetEnvironmentVariable("PASSWORD"), "Google");
-            DotNetEnv.Env.Load(true, false);
-            Assert.Equal(Environment.GetEnvironmentVariable("PASSWORD"), "Google#Facebook");
-            DotNetEnv.Env.Load(true, true, true);
-            Assert.Equal(Environment.GetEnvironmentVariable("SSL_CERT"), "SPECIAL STUFF---\nLONG-BASE64\\ignore\"slash");
-            DotNetEnv.Env.Load(true, true, false);
-            Assert.Equal(Environment.GetEnvironmentVariable("SSL_CERT"), "\"SPECIAL STUFF---\\nLONG-BASE64\\ignore\"slash\"");
-        }
-
-        [Fact]
-        public void ObsoleteLoadPathArgsTest()
-        {
-            DotNetEnv.Env.Load("./.env2", true, true);
-            Assert.Equal(Environment.GetEnvironmentVariable("WHITELEAD"), "leading white space followed by comment");
-            DotNetEnv.Env.Load("./.env2", false, true);
-            Assert.Equal(Environment.GetEnvironmentVariable("WHITELEAD"), "  leading white space followed by comment  ");
-            DotNetEnv.Env.Load("./.env2", true, false);
-            Assert.Equal(Environment.GetEnvironmentVariable("WHITELEAD"), "leading white space followed by comment  # comment");
-            DotNetEnv.Env.Load("./.env2", false, false);
-            Assert.Equal(Environment.GetEnvironmentVariable("WHITELEAD"), "  leading white space followed by comment  # comment");
-            DotNetEnv.Env.Load("./.env2", false, false, true);
-            Assert.Equal(Environment.GetEnvironmentVariable("UNICODE"), "® 🚀 日本");
-            DotNetEnv.Env.Load("./.env2", false, false, false);
-            Assert.Equal(Environment.GetEnvironmentVariable("UNICODE"), "'\\u00ae \\U0001F680 日本'");
-        }
-
-        [Fact]
-        public void ObsoleteLoadNoClobberTest()
-        {
-            var expected = "totally the original value";
-            Environment.SetEnvironmentVariable("URL", expected);
-            DotNetEnv.Env.Load(false, false, false, false);
-            Assert.Equal(Environment.GetEnvironmentVariable("URL"), expected);
-
-            Environment.SetEnvironmentVariable("URL", "i'm going to be overwritten");
-            DotNetEnv.Env.Load(false, false, false, true);
-            Assert.Equal(Environment.GetEnvironmentVariable("URL"), "https://github.com/tonerdo");
-        }
-
-        [Fact]
-        public void ObsoleteLoadOsCasingTest()
-        {
-            Environment.SetEnvironmentVariable("CASING", "neither");
-            DotNetEnv.Env.Load("./.env3", clobberExistingVars: false);
-            Assert.Equal(Environment.GetEnvironmentVariable("casing"), IsWindows ? "neither" : "lower");
-            Assert.Equal(Environment.GetEnvironmentVariable("CASING"), "neither");
-
-            DotNetEnv.Env.Load("./.env3", clobberExistingVars: true);
-            Assert.Equal(Environment.GetEnvironmentVariable("casing"), "lower");
-            Assert.Equal(Environment.GetEnvironmentVariable("CASING"), IsWindows ? "lower" : "neither");
-
-            Environment.SetEnvironmentVariable("CASING", null);
-            Environment.SetEnvironmentVariable("casing", "neither");
-            DotNetEnv.Env.Load("./.env3", clobberExistingVars: false);
-            Assert.Equal(Environment.GetEnvironmentVariable("casing"), "neither");
-            Assert.Equal(Environment.GetEnvironmentVariable("CASING"), IsWindows ? "neither" : null);
-
-            DotNetEnv.Env.Load("./.env3", clobberExistingVars: true);
-            Assert.Equal(Environment.GetEnvironmentVariable("casing"), "lower");
-            Assert.Equal(Environment.GetEnvironmentVariable("CASING"), IsWindows ? "lower" : null);
-        }
-
-        #endregion
     }
 }


### PR DESCRIPTION
obsolete Load, require env false, etc

I also bumped the version up to 1.4.0 so as to give people a choice: use 1.3.1 with the old parameters list, or jump up to 1.4.0 to use only the new stuff -- notably require env var defaulting to false, such that no dummy .env file needs to present in prod (which is completely absolutely not how this should work -- only use this functionality in localdev!!!!)