### PR TITLE
Added support for hash inside quote string values.

### DIFF
--- a/src/DotNetEnv/Parser.cs
+++ b/src/DotNetEnv/Parser.cs
@@ -15,10 +15,26 @@ namespace DotNetEnv
             return line.Trim().StartsWith("#");
         }
 
+        private static string GetQuotedValue(string input, string delimeter)
+        {
+            if (input.Contains(delimeter))
+            {
+                int quoteStart = input.IndexOf(delimeter);
+                int quoteEnd = input.LastIndexOf(delimeter)+1;
+                return input.Substring(quoteStart, quoteEnd);
+            }
+            return input;
+        }
         private static string RemoveInlineComment(string line)
         {
-            int pos = line.IndexOf('#');
-            return pos >= 0 ? line.Substring(0, pos) : line;
+            string value = GetQuotedValue(line, "\"");
+            value = GetQuotedValue(value, "\'");
+
+            if (IsQuoted(value))
+                return value;
+      
+            int pos = value.IndexOf('#');
+            return pos >= 0 ? value.Substring(0, pos) : line;
         }
 
         private static string RemoveExportKeyword(string line)
@@ -75,11 +91,6 @@ namespace DotNetEnv
                 if (IsComment(line))
                     continue;
 
-                if (isEmbeddedHashComment)
-                {
-                    line = RemoveInlineComment(line);
-                }
-
                 line = RemoveExportKeyword(line);
 
                 string[] keyValuePair = line.Split(new char[] { '=' }, 2);
@@ -87,6 +98,11 @@ namespace DotNetEnv
                 // skip malformed lines
                 if (keyValuePair.Length != 2)
                     continue;
+
+                if (isEmbeddedHashComment)
+                {
+                    keyValuePair[1] = RemoveInlineComment(keyValuePair[1]);
+                }
 
                 if (trimWhitespace)
                 {

--- a/test/DotNetEnv.Tests/.env5
+++ b/test/DotNetEnv.Tests/.env5
@@ -1,0 +1,14 @@
+﻿#Test Env File for Comment variations
+
+QTEST1=1234#this is a comment
+
+#Double Quoted Variables
+QTEST="1234#this is not a comment"
+QTEST2="This is a test" #please ignore
+QTEST3="1234 #not_comment" #please ignore
+
+#Single Quoted Variables
+QTEST4='9876#this is not a comment'
+QTEST5='This is a another test' #please ignore
+QTEST6='9876 #not_comment' #please ignore
+

--- a/test/DotNetEnv.Tests/DotNetEnv.Tests.csproj
+++ b/test/DotNetEnv.Tests/DotNetEnv.Tests.csproj
@@ -33,6 +33,9 @@
     <None Update=".env4">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update=".env5">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/test/DotNetEnv.Tests/EnvTests.cs
+++ b/test/DotNetEnv.Tests/EnvTests.cs
@@ -159,5 +159,53 @@ namespace DotNetEnv.Tests
             Assert.Equal(Environment.GetEnvironmentVariable("TEST4"), "testtest1");
             Assert.Equal(Environment.GetEnvironmentVariable("TEST5"), "test:testtest1 and test1");
         }
+
+        [Fact]
+        public void HashIgnoredWhenValueDoubleQuoted()
+        {
+            DotNetEnv.Env.Load("./.env5");
+        }
+
+        [Fact]
+        public void InlineCommentsRemovedWhenValueNotDoubleQuoted()
+        {
+            DotNetEnv.Env.Load("./.env5");
+            Assert.Equal("1234", Environment.GetEnvironmentVariable("QTEST1"));
+        }
+
+        [Fact]
+        public void CommentAfterDoubleQuotedStringIsIgnored()
+        {
+            DotNetEnv.Env.Load("./.env5");
+            Assert.Equal("This is a test", Environment.GetEnvironmentVariable("QTEST2"));
+        }
+
+        [Fact]
+        public void HashIgnoredWhenValueDoubleQuotedCommentOutsideIgnored()
+        {
+            DotNetEnv.Env.Load("./.env5");
+            Assert.Equal("1234 #not_comment", Environment.GetEnvironmentVariable("QTEST3"));
+        }
+
+        [Fact]
+        public void HashIgnoredWhenValueSingleQuoted()
+        {
+            DotNetEnv.Env.Load("./.env5");
+            Assert.Equal("9876#this is not a comment", Environment.GetEnvironmentVariable("QTEST4"));
+        }
+
+        [Fact]
+        public void CommentAfterSingleQuotedStringIsIgnored()
+        {
+            DotNetEnv.Env.Load("./.env5");
+            Assert.Equal("This is a another test", Environment.GetEnvironmentVariable("QTEST5"));
+        }
+
+        [Fact]
+        public void HashIgnoredWhenValueSingleQuotedCommentOutsideIgnored()
+        {
+            DotNetEnv.Env.Load("./.env5");
+            Assert.Equal("9876 #not_comment", Environment.GetEnvironmentVariable("QTEST6"));
+        }
     }
 }


### PR DESCRIPTION
The current implementation removes anything after hash characters (comments) inside of quoted strings such as 
TEST= "test #1234"

The change in this PR allows for hash characters to exist inside of values that are quoted by either single or double quotes.

The variations supported here include:

Double Quotes:
- test="1234#this is not a comment"
- test="This is a test" #please ignore
- test="1234 #not_comment" #please ignore

Single Quotes:
- test='9876#this is not a comment'
- test='This is a another test' #please ignore
- test='9876 #not_comment' #please ignore

As part of the PR , I added a .env5 file to the tests project and also added granular supported unit tests.

Thanks!