### PR TITLE
#40 surface a Parse method to return variables as dictionary

### DIFF
--- a/src/DotNetEnv/Env.cs
+++ b/src/DotNetEnv/Env.cs
@@ -11,27 +11,87 @@ namespace DotNetEnv
 
         private static LoadOptions DEFAULT_OPTIONS = new LoadOptions();
 
+        private static void Load(Dictionary<string, string> envFile, LoadOptions options = null)
+        {
+            if (envFile == null) return; // since we don't require the target file to exist, just do nothing here
+            if (options == null) throw new ArgumentNullException(nameof(options)); // internal call, all callers should be populating this
+
+            LoadVars.SetEnvironmentVariables(envFile, options.ClobberExistingVars);
+        }
+
         public static void Load(string[] lines, LoadOptions options = null)
         {
             if (options == null) options = DEFAULT_OPTIONS;
 
-            Vars envFile = Parser.Parse(
+            var envFile = Parse(lines, options);
+            Load(envFile, options);
+        }
+
+        public static void Load(string path, LoadOptions options = null)
+        {
+            if (options == null) options = DEFAULT_OPTIONS;
+
+            var envFile = Parse(path, options);
+            Load(envFile, options);
+        }
+
+        public static void Load(Stream file, LoadOptions options = null)
+        {
+            if (options == null) options = DEFAULT_OPTIONS;
+
+            var envFile = Parse(file, options);
+            Load(envFile, options);
+        }
+
+        public static void Load(LoadOptions options = null) =>
+            Load(Path.Combine(Directory.GetCurrentDirectory(), DEFAULT_ENVFILENAME), options);
+
+        public static Dictionary<string, string> Parse(string[] lines, ParseOptions options = null)
+        {
+            if (options == null) options = DEFAULT_OPTIONS;
+
+            var envFile = Parser.Parse(
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
                 lines,
                 options.TrimWhitespace,
                 options.IsEmbeddedHashComment,
                 options.UnescapeQuotedValues,
                 options.ParseVariables
             );
-            LoadVars.SetEnvironmentVariables(envFile, options.ClobberExistingVars);
+            return envFile;
         }
 
-        public static void Load(string path, LoadOptions options = null)
+        public static Dictionary<string, string> Parse(string path, ParseOptions options = null)
         {
-            if (!File.Exists(path)) return;
-            Load(File.ReadAllLines(path), options);
+            if (!File.Exists(path)) return null;
+            return Parse(File.ReadAllLines(path), options);
         }
 
-        public static void Load(Stream file, LoadOptions options = null)
+        public static Dictionary<string, string> Parse(Stream file, ParseOptions options = null)
         {
             var lines = new List<string>();
             var currentLine = "";
@@ -43,11 +103,11 @@ namespace DotNetEnv
                     if (currentLine != null) lines.Add(currentLine);
                 }
             }
-            Load(lines.ToArray(), options);
+            return Parse(lines.ToArray(), options);
         }
 
-        public static void Load(LoadOptions options = null) =>
-            Load(Path.Combine(Directory.GetCurrentDirectory(), DEFAULT_ENVFILENAME), options);
+        public static Dictionary<string, string> Parse(ParseOptions options = null) =>
+            Parse(Path.Combine(Directory.GetCurrentDirectory(), DEFAULT_ENVFILENAME), options);
 
         public static string GetString(string key, string fallback = default(string)) =>
             Environment.GetEnvironmentVariable(key) ?? fallback;
@@ -61,13 +121,30 @@ namespace DotNetEnv
         public static double GetDouble(string key, double fallback = default(double)) =>
             double.TryParse(Environment.GetEnvironmentVariable(key), NumberStyles.Any, CultureInfo.InvariantCulture, out var value) ? value : fallback;
 
-        public class LoadOptions
+        public class ParseOptions
         {
             public bool TrimWhitespace { get; }
             public bool IsEmbeddedHashComment { get; }
             public bool UnescapeQuotedValues { get; }
-            public bool ClobberExistingVars { get; }
             public bool ParseVariables { get; }
+
+            public ParseOptions(
+                bool trimWhitespace = true,
+                bool isEmbeddedHashComment = true,
+                bool unescapeQuotedValues = true,
+                bool parseVariables = true
+            )
+            {
+                TrimWhitespace = trimWhitespace;
+                IsEmbeddedHashComment = isEmbeddedHashComment;
+                UnescapeQuotedValues = unescapeQuotedValues;
+                ParseVariables = parseVariables;
+            }
+        }
+
+        public class LoadOptions : ParseOptions
+        {
+            public bool ClobberExistingVars { get; }
 
             public LoadOptions(
                 bool trimWhitespace = true,
@@ -75,13 +152,9 @@ namespace DotNetEnv
                 bool unescapeQuotedValues = true,
                 bool clobberExistingVars = true,
                 bool parseVariables = true
-            )
+            ) : base(trimWhitespace, isEmbeddedHashComment, unescapeQuotedValues, parseVariables)
             {
-                TrimWhitespace = trimWhitespace;
-                IsEmbeddedHashComment = isEmbeddedHashComment;
-                UnescapeQuotedValues = unescapeQuotedValues;
                 ClobberExistingVars = clobberExistingVars;
-                ParseVariables = parseVariables;
             }
         }
     }

--- a/src/DotNetEnv/LoadVars.cs
+++ b/src/DotNetEnv/LoadVars.cs
@@ -1,10 +1,11 @@
 using System;
+using System.Collections.Generic;
 
 namespace DotNetEnv
 {
     internal class LoadVars
     {
-        public static void SetEnvironmentVariables(Vars vars, bool clobberExistingVars = true)
+        public static void SetEnvironmentVariables(Dictionary<string, string> vars, bool clobberExistingVars = true)
         {
             foreach (var keyValuePair in vars)
             {

--- a/test/DotNetEnv.Tests/EnvTests.cs
+++ b/test/DotNetEnv.Tests/EnvTests.cs
@@ -36,7 +36,7 @@ namespace DotNetEnv.Tests
             Assert.Equal("leading white space followed by comment", Environment.GetEnvironmentVariable("WHITELEAD"));
             Assert.Equal("® 🚀 日本", Environment.GetEnvironmentVariable("UNICODE"));
         }
-        
+
         [Fact]
         public void LoadStreamTest()
         {
@@ -51,7 +51,7 @@ namespace DotNetEnv.Tests
             Assert.Equal("leading and trailing white space", Environment.GetEnvironmentVariable("WHITEBOTH"));
             Assert.Equal("SPECIAL STUFF---\nLONG-BASE64\\ignore\"slash", Environment.GetEnvironmentVariable("SSL_CERT"));
         }
-        
+
         [Fact]
         public void LoadLinesTest()
         {
@@ -158,6 +158,92 @@ namespace DotNetEnv.Tests
             Assert.Equal("testtest", Environment.GetEnvironmentVariable("TEST3"));
             Assert.Equal("testtest1", Environment.GetEnvironmentVariable("TEST4"));
             Assert.Equal("test:testtest1 and test1", Environment.GetEnvironmentVariable("TEST5"));
+        }
+
+        [Fact]
+        public void ParseTest()
+        {
+            var dict = DotNetEnv.Env.Parse();
+            Assert.Equal("Toni", dict["NAME"]);
+            Assert.Equal("", dict["EMPTY"]);
+            Assert.Equal("'", dict["QUOTE"]);
+            Assert.Equal("https://github.com/tonerdo", dict["URL"]);
+            Assert.Equal("user=test;password=secret", dict["CONNECTION"]);
+            Assert.Equal("leading and trailing white space", dict["WHITEBOTH"]);
+            Assert.Equal("SPECIAL STUFF---\nLONG-BASE64\\ignore\"slash", dict["SSL_CERT"]);
+        }
+
+        [Fact]
+        public void ParsePathTest()
+        {
+            var dict = DotNetEnv.Env.Parse("./.env2");
+            Assert.Equal("127.0.0.1", dict["IP"]);
+            Assert.Equal("8080", dict["PORT"]);
+            Assert.Equal("example.com", dict["DOMAIN"]);
+            Assert.Equal("some text export other text", dict["EMBEDEXPORT"]);
+            Assert.False(dict.ContainsKey("COMMENTLEAD"));
+            Assert.Equal("leading white space followed by comment", dict["WHITELEAD"]);
+            Assert.Equal("® 🚀 日本", dict["UNICODE"]);
+        }
+
+        [Fact]
+        public void ParseStreamTest()
+        {
+            var dict = DotNetEnv.Env.Parse(File.OpenRead("./.env"));
+            Assert.Equal("Toni", dict["NAME"]);
+            Assert.Equal("", dict["EMPTY"]);
+            Assert.Equal("'", dict["QUOTE"]);
+            Assert.Equal("https://github.com/tonerdo", dict["URL"]);
+            Assert.Equal("user=test;password=secret", dict["CONNECTION"]);
+            Assert.Equal("leading and trailing white space", dict["WHITEBOTH"]);
+            Assert.Equal("SPECIAL STUFF---\nLONG-BASE64\\ignore\"slash", dict["SSL_CERT"]);
+        }
+
+        [Fact]
+        public void ParseLinesTest()
+        {
+            var dict = DotNetEnv.Env.Parse(File.ReadAllLines("./.env"));
+            Assert.Equal("Toni", dict["NAME"]);
+            Assert.Equal("", dict["EMPTY"]);
+            Assert.Equal("'", dict["QUOTE"]);
+            Assert.Equal("https://github.com/tonerdo", dict["URL"]);
+            Assert.Equal("user=test;password=secret", dict["CONNECTION"]);
+            Assert.Equal("leading and trailing white space", dict["WHITEBOTH"]);
+            Assert.Equal("SPECIAL STUFF---\nLONG-BASE64\\ignore\"slash", dict["SSL_CERT"]);
+        }
+
+        [Fact]
+        public void ParseArgsTest()
+        {
+            var dict = DotNetEnv.Env.Parse(new DotNetEnv.Env.ParseOptions(true));
+            Assert.Equal("leading and trailing white space", dict["WHITEBOTH"]);
+            dict = DotNetEnv.Env.Parse(new DotNetEnv.Env.ParseOptions(false));
+            Assert.Equal("  leading and trailing white space   ", Environment.GetEnvironmentVariable("  WHITEBOTH  "));
+            dict = DotNetEnv.Env.Parse(new DotNetEnv.Env.ParseOptions(true, true));
+            Assert.Equal("Google", dict["PASSWORD"]);
+            dict = DotNetEnv.Env.Parse(new DotNetEnv.Env.ParseOptions(true, false));
+            Assert.Equal("Google#Facebook", dict["PASSWORD"]);
+            dict = DotNetEnv.Env.Parse(new DotNetEnv.Env.ParseOptions(true, true, true));
+            Assert.Equal("SPECIAL STUFF---\nLONG-BASE64\\ignore\"slash", dict["SSL_CERT"]);
+            dict = DotNetEnv.Env.Parse(new DotNetEnv.Env.ParseOptions(true, true, false));
+            Assert.Equal("\"SPECIAL STUFF---\\nLONG-BASE64\\ignore\"slash\"", dict["SSL_CERT"]);
+        }
+
+        [Fact]
+        public void ParsePathArgsTest()
+        {
+            var dict = DotNetEnv.Env.Parse("./.env2", new DotNetEnv.Env.ParseOptions(true, true));
+            Assert.Equal("leading white space followed by comment", dict["WHITELEAD"]);
+            dict = DotNetEnv.Env.Parse("./.env2", new DotNetEnv.Env.ParseOptions(false, true));
+            Assert.Equal("  leading white space followed by comment  ", dict["WHITELEAD"]);
+            dict = DotNetEnv.Env.Parse("./.env2", new DotNetEnv.Env.ParseOptions(true, false));
+            Assert.Equal("leading white space followed by comment  # comment", dict["WHITELEAD"]);
+            dict = DotNetEnv.Env.Parse("./.env2", new DotNetEnv.Env.ParseOptions(false, false));
+            Assert.Equal("  leading white space followed by comment  # comment", dict["WHITELEAD"]);
+            dict = DotNetEnv.Env.Parse("./.env2", new DotNetEnv.Env.ParseOptions(false, false, true));
+            Assert.Equal("® 🚀 日本", dict["UNICODE"]);
+            dict = DotNetEnv.Env.Parse("./.env2", new DotNetEnv.Env.ParseOptions(false, false, false));
+            Assert.Equal("'\\u00ae \\U0001F680 日本'", dict["UNICODE"]);
         }
     }
 }


### PR DESCRIPTION
This is the initial version I had made before the response that recommended parsetodict and renaming parsetoenv.  I'm happy to continue with renames / deprecation if you want, but figured it was worth at least showing what I had initially made in case it was useful.

Main thoughts:
* Load is still a good method name, as it actively modifies the environment.  Generally API's named parse just return an in-memory thing, so "parse to env" could be a confusing term.
* it seems like deprecating Load for eventual removal is kind of harsh for consumers, especially since we're not changing the behavior.
* since most of the LoadOptions are about handling parsing behavior and only the clobber affects load behavior, this extracts a ParseOptions under it for most of the options
* while most of the existing Load tests were testing parse behavior, I left them alone to help ensure the behavior didn't change and just added ones for Parse

I'm still happy to change it, just wanted to share what I'd initially written.

Thanks, @rogusdev !