### PR TITLE
Add ConfigurationProvider to integrate with standard .NET providers

### DIFF
--- a/DotNetEnv.sln
+++ b/DotNetEnv.sln
@@ -1,17 +1,29 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.33205.214
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E1CC46FC-4D7C-42C0-8F3A-BCB1B45CD459}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetEnv", "src\DotNetEnv\DotNetEnv.csproj", "{56AE6D80-197D-426C-B4A3-B1F329263B71}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotNetEnv", "src\DotNetEnv\DotNetEnv.csproj", "{56AE6D80-197D-426C-B4A3-B1F329263B71}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{DECBE6ED-4F14-424C-BEF1-0B9D45EEDB79}"
+	ProjectSection(SolutionItems) = preProject
+		test\.env = test\.env
+	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetEnv.Tests", "test\DotNetEnv.Tests\DotNetEnv.Tests.csproj", "{062FD47B-69A9-4808-97CA-CF24CD65B0F0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotNetEnv.Tests", "test\DotNetEnv.Tests\DotNetEnv.Tests.csproj", "{062FD47B-69A9-4808-97CA-CF24CD65B0F0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetEnvTraverse.Tests", "test\DotNetEnvTraverse.Tests\DotNetEnvTraverse.Tests.csproj", "{947252C9-700A-4A6E-A9EA-DFA6631916EF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotNetEnvTraverse.Tests", "test\DotNetEnvTraverse.Tests\DotNetEnvTraverse.Tests.csproj", "{947252C9-700A-4A6E-A9EA-DFA6631916EF}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{C5790CAC-6A56-45A4-8AC9-EA2D0C7120A8}"
+	ProjectSection(SolutionItems) = preProject
+		.env_much_higher = .env_much_higher
+		.gitignore = .gitignore
+		appveyor.yml = appveyor.yml
+		LICENSE = LICENSE
+		README.md = README.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,9 +33,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{56AE6D80-197D-426C-B4A3-B1F329263B71}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -63,9 +72,15 @@ Global
 		{947252C9-700A-4A6E-A9EA-DFA6631916EF}.Release|x86.ActiveCfg = Release|Any CPU
 		{947252C9-700A-4A6E-A9EA-DFA6631916EF}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{56AE6D80-197D-426C-B4A3-B1F329263B71} = {E1CC46FC-4D7C-42C0-8F3A-BCB1B45CD459}
 		{062FD47B-69A9-4808-97CA-CF24CD65B0F0} = {DECBE6ED-4F14-424C-BEF1-0B9D45EEDB79}
 		{947252C9-700A-4A6E-A9EA-DFA6631916EF} = {DECBE6ED-4F14-424C-BEF1-0B9D45EEDB79}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {DD9551C5-6762-4AB7-BF95-E02EC1EE2285}
 	EndGlobalSection
 EndGlobal

--- a/DotNetEnv.sln
+++ b/DotNetEnv.sln
@@ -21,6 +21,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.env_much_higher = .env_much_higher
 		.gitignore = .gitignore
 		appveyor.yml = appveyor.yml
+		global.json = global.json
 		LICENSE = LICENSE
 		README.md = README.md
 	EndProjectSection

--- a/README.md
+++ b/README.md
@@ -161,6 +161,18 @@ See `DotNetEnvTraverse.Tests` for examples.
 DotNetEnv.Env.TraversePath().Load();
 ```
 
+### Using .NET Configuration provider
+
+Integrating with the usual ConfigurationBuilder used in .NET is simple!
+
+```
+var configuration = new ConfigurationBuilder()
+    .AddDotNetEnv(".env", LoadOptions.TraversePath()) // Simply add the DotNetEnv configuration source!
+    .Build();
+```
+
+The configuration provider will map `__` as `:` to allow sections!
+
 ## .env file structure
 
 All lines must be valid assignments or empty lines (with optional comments).

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,6 @@ configuration:
   - Release
 build_script:
   - echo "Building for %CONFIGURATION%"
-  - dotnet --list-sdks
   - dotnet restore
   - dotnet build -c %CONFIGURATION%
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ configuration:
   - Release
 build_script:
   - echo "Building for %CONFIGURATION%"
+  - dotnet --list-sdks
   - dotnet restore
   - dotnet build -c %CONFIGURATION%
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 version: '1.0.0.{build}'
+image: Visual Studio 2019
 configuration:
   - Debug
   - Release

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "3.0.0",
+    "rollForward": "minor"
+  },
+  "projects": ["src", "test"]
+}

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.0.0",
+    "version": "3.1.0",
     "rollForward": "minor"
   },
   "projects": ["src", "test"]

--- a/src/DotNetEnv/Configuration/ConfigurationBuilderExtensions.cs
+++ b/src/DotNetEnv/Configuration/ConfigurationBuilderExtensions.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.Extensions.Configuration;
+
+namespace DotNetEnv.Configuration
+{
+    public static class ConfigurationBuilderExtensions
+    {
+        public static IConfigurationBuilder AddDotNetEnv(
+            this IConfigurationBuilder builder,
+            string path = null,
+            LoadOptions options = null)
+        {
+
+            builder.Add(new EnvConfigurationSource(path == null ? null : new[] { path }, options));
+            return builder;
+        }
+
+        public static IConfigurationBuilder AddDotNetEnvMulti(
+            this IConfigurationBuilder builder,
+            string[] paths,
+            LoadOptions options = null)
+        {
+            builder.Add(new EnvConfigurationSource(paths, options));
+            return builder;
+        }
+    }
+}

--- a/src/DotNetEnv/Configuration/EnvConfigurationProvider.cs
+++ b/src/DotNetEnv/Configuration/EnvConfigurationProvider.cs
@@ -39,18 +39,20 @@ namespace DotNetEnv.Configuration
             // Since the Load method does not take car of cloberring, We have to check it here!
             foreach (var value in values)
             {
+                var key = NormalizeKey(value.Key);
                 if (this.options.ClobberExistingVars)
                 {
-                    this.Data[value.Key] = value.Value;
+                    this.Data[key] = value.Value;
                 }
                 else
                 {
-                    if (!this.Data.ContainsKey(value.Key))
+                    if (!this.Data.ContainsKey(key))
                     {
-                        this.Data.Add(value.Key, value.Value);
+                        this.Data.Add(key, value.Value);
                     }
                 }
             }
         }
+        private static string NormalizeKey(string key) => key.Replace("__", ConfigurationPath.KeyDelimiter);
     }
 }

--- a/src/DotNetEnv/Configuration/EnvConfigurationProvider.cs
+++ b/src/DotNetEnv/Configuration/EnvConfigurationProvider.cs
@@ -36,7 +36,7 @@ namespace DotNetEnv.Configuration
                 }
             }
 
-            // Since the Load method does not take car of cloberring, We have to check it here!
+            // Since the Load method does not take care of cloberring, We have to check it here!
             foreach (var value in values)
             {
                 var key = NormalizeKey(value.Key);

--- a/src/DotNetEnv/Configuration/EnvConfigurationProvider.cs
+++ b/src/DotNetEnv/Configuration/EnvConfigurationProvider.cs
@@ -1,0 +1,56 @@
+﻿using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+
+namespace DotNetEnv.Configuration
+{
+    public class EnvConfigurationProvider : ConfigurationProvider
+    {
+        private readonly string[] paths;
+
+        private readonly LoadOptions options;
+
+        public EnvConfigurationProvider(
+            string[] paths,
+            LoadOptions options)
+        {
+            this.paths = paths;
+            this.options = (options ?? LoadOptions.DEFAULT).NoEnvVars();
+        }
+
+        public override void Load()
+        {
+            IEnumerable<KeyValuePair<string, string>> values;
+            if (this.paths == null)
+            {
+                values = Env.Load(options: this.options);
+            }
+            else
+            {
+                if (this.paths.Length == 1)
+                {
+                    values = Env.Load(this.paths[0], this.options);
+                }
+                else
+                {
+                    values = Env.LoadMulti(this.paths, this.options);
+                }
+            }
+
+            // Since the Load method does not take car of cloberring, We have to check it here!
+            foreach (var value in values)
+            {
+                if (this.options.ClobberExistingVars)
+                {
+                    this.Data[value.Key] = value.Value;
+                }
+                else
+                {
+                    if (!this.Data.ContainsKey(value.Key))
+                    {
+                        this.Data.Add(value.Key, value.Value);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/DotNetEnv/Configuration/EnvConfigurationProvider.cs
+++ b/src/DotNetEnv/Configuration/EnvConfigurationProvider.cs
@@ -14,7 +14,7 @@ namespace DotNetEnv.Configuration
             LoadOptions options)
         {
             this.paths = paths;
-            this.options = (options ?? LoadOptions.DEFAULT).NoEnvVars();
+            this.options = options ?? LoadOptions.DEFAULT;
         }
 
         public override void Load()

--- a/src/DotNetEnv/Configuration/EnvConfigurationSource.cs
+++ b/src/DotNetEnv/Configuration/EnvConfigurationSource.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+
+namespace DotNetEnv.Configuration
+{
+    public class EnvConfigurationSource : IConfigurationSource
+    {
+        private readonly string[] paths;
+
+        private readonly LoadOptions options;
+
+        public EnvConfigurationSource(
+            string[] paths,
+            LoadOptions options)
+        {
+            this.paths = paths;
+            this.options = options;
+        }
+
+        public IConfigurationProvider Build(IConfigurationBuilder builder)
+        {
+            return new EnvConfigurationProvider(this.paths, this.options);
+        }
+    }
+}

--- a/src/DotNetEnv/DotNetEnv.csproj
+++ b/src/DotNetEnv/DotNetEnv.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Title>DotNetEnv</Title>
     <Description>A .NET library to load environment variables from .env files</Description>
@@ -21,6 +21,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="1.1.2" />
     <PackageReference Include="Sprache" Version="2.3.1" />
   </ItemGroup>
 </Project>

--- a/test/DotNetEnv.Tests/.env_sections
+++ b/test/DotNetEnv.Tests/.env_sections
@@ -1,0 +1,2 @@
+SECTION__Key1=value1
+SECTION__Key2=value2

--- a/test/DotNetEnv.Tests/AssemblyInfo.cs
+++ b/test/DotNetEnv.Tests/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+﻿using Xunit;
+
+// Make one collection per class, since multiple classes now play with environment variables
+// At the same time!
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerClass)]

--- a/test/DotNetEnv.Tests/DotNetEnv.Tests.csproj
+++ b/test/DotNetEnv.Tests/DotNetEnv.Tests.csproj
@@ -32,6 +32,9 @@
     <None Include="./.env_examples">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/DotNetEnv.Tests/DotNetEnv.Tests.csproj
+++ b/test/DotNetEnv.Tests/DotNetEnv.Tests.csproj
@@ -45,4 +45,10 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update=".env_sections">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/test/DotNetEnv.Tests/EnvConfigurationTests.cs
+++ b/test/DotNetEnv.Tests/EnvConfigurationTests.cs
@@ -1,0 +1,70 @@
+﻿using DotNetEnv.Configuration;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace DotNetEnv.Tests
+{
+    /// <summary>
+    /// This class tests a few basic operations, but the settings are mostly passed directly
+    /// to `DotNetEnv.Env.Load()`
+    /// </summary>
+    public class EnvConfigurationTests
+    {
+        [Fact]
+        public void AddSourceToBuilderAndLoad()
+        {
+            var config = new ConfigurationBuilder()
+                .AddDotNetEnv()
+                .Build();
+
+            Assert.Empty(config["EMPTY"]);
+            Assert.Equal("'", config["QUOTE"]);
+            Assert.Equal("https://github.com/tonerdo", config["URL"]);
+            Assert.Equal("user=test;password=secret", config["CONNECTION"]);
+            Assert.Equal("  leading and trailing white space   ", config["WHITEBOTH"]);
+            Assert.Equal("SPECIAL STUFF---\nLONG-BASE64\\ignore\"slash", config["SSL_CERT"]);
+        }
+
+        [Fact]
+        public void AddSourceToBuilderAndLoadDotenvHigherSkip()
+        {
+            // ./DotNetEnv.Tests/bin/Debug/netcoreapp3.1/DotNetEnv.Tests.dll -- get to the ./ (root of `test` folder)
+            var config = new ConfigurationBuilder()
+                .AddDotNetEnv("../../../../")
+                .Build();
+
+            Assert.Null(config["NAME"]);
+            Assert.Equal("here", config["TEST"]);
+        }
+
+        [Fact]
+        public void AddSourceToBuilderAndLoadMulti()
+        {
+            var config = new ConfigurationBuilder()
+                .AddDotNetEnvMulti(new[] { "./.env", "./.env2" })
+                .Build();
+
+            Assert.Equal("Other", config["NAME"]);
+        }
+
+        [Fact]
+        public void AddSourceToBuilderAndLoadMultiWithNoClobber()
+        {
+            var config = new ConfigurationBuilder()
+                .AddDotNetEnvMulti(new[] { "./.env", "./.env2" }, LoadOptions.NoClobber())
+                .Build();
+
+            Assert.Equal("Toni", config["NAME"]);
+        }
+
+        [Fact]
+        public void AddSourceToBuilderAndFileDoesNotExist()
+        {
+            var config = new ConfigurationBuilder()
+                .AddDotNetEnv("./.env_DNE")
+                .Build();
+
+            Assert.Empty(config.AsEnumerable());
+        }
+    }
+}

--- a/test/DotNetEnv.Tests/EnvConfigurationTests.cs
+++ b/test/DotNetEnv.Tests/EnvConfigurationTests.cs
@@ -1,4 +1,5 @@
-﻿using DotNetEnv.Configuration;
+﻿using System;
+using DotNetEnv.Configuration;
 using Microsoft.Extensions.Configuration;
 using Xunit;
 
@@ -8,76 +9,135 @@ namespace DotNetEnv.Tests
     /// This class tests a few basic operations, but the settings are mostly passed directly
     /// to `DotNetEnv.Env.Load()`
     /// </summary>
-    public class EnvConfigurationTests
+    public class EnvConfigurationTests : IDisposable
     {
+        private IConfigurationRoot configuration;
+
+        public void Dispose()
+        {
+            foreach (var conf in this.configuration.AsEnumerable())
+            {
+                Environment.SetEnvironmentVariable(conf.Key, null);
+            }
+        }
+
+
         [Fact]
         public void AddSourceToBuilderAndLoad()
         {
-            var config = new ConfigurationBuilder()
-                .AddDotNetEnv()
+            this.configuration = new ConfigurationBuilder()
+                .AddDotNetEnv(options: LoadOptions.NoEnvVars())
                 .Build();
 
-            Assert.Empty(config["EMPTY"]);
-            Assert.Equal("'", config["QUOTE"]);
-            Assert.Equal("https://github.com/tonerdo", config["URL"]);
-            Assert.Equal("user=test;password=secret", config["CONNECTION"]);
-            Assert.Equal("  leading and trailing white space   ", config["WHITEBOTH"]);
-            Assert.Equal("SPECIAL STUFF---\nLONG-BASE64\\ignore\"slash", config["SSL_CERT"]);
+            Assert.Empty(this.configuration["EMPTY"]);
+            Assert.Equal("'", this.configuration["QUOTE"]);
+            Assert.Equal("https://github.com/tonerdo", this.configuration["URL"]);
+            Assert.Equal("user=test;password=secret", this.configuration["CONNECTION"]);
+            Assert.Equal("  leading and trailing white space   ", this.configuration["WHITEBOTH"]);
+            Assert.Equal("SPECIAL STUFF---\nLONG-BASE64\\ignore\"slash", this.configuration["SSL_CERT"]);
         }
 
         [Fact]
         public void AddSourceToBuilderAndLoadDotenvHigherSkip()
         {
             // ./DotNetEnv.Tests/bin/Debug/netcoreapp3.1/DotNetEnv.Tests.dll -- get to the ./ (root of `test` folder)
-            var config = new ConfigurationBuilder()
-                .AddDotNetEnv("../../../../")
+            this.configuration = new ConfigurationBuilder()
+                .AddDotNetEnv("../../../../", LoadOptions.NoEnvVars())
                 .Build();
 
-            Assert.Null(config["NAME"]);
-            Assert.Equal("here", config["TEST"]);
+            Assert.Null(this.configuration["NAME"]);
+            Assert.Equal("here", this.configuration["TEST"]);
         }
 
         [Fact]
         public void AddSourceToBuilderAndLoadMulti()
         {
-            var config = new ConfigurationBuilder()
-                .AddDotNetEnvMulti(new[] { "./.env", "./.env2" })
+            this.configuration = new ConfigurationBuilder()
+                .AddDotNetEnvMulti(new[] { "./.env", "./.env2" }, LoadOptions.NoEnvVars())
                 .Build();
 
-            Assert.Equal("Other", config["NAME"]);
+            Assert.Equal("Other", this.configuration["NAME"]);
         }
 
         [Fact]
         public void AddSourceToBuilderAndLoadMultiWithNoClobber()
         {
-            var config = new ConfigurationBuilder()
-                .AddDotNetEnvMulti(new[] { "./.env", "./.env2" }, LoadOptions.NoClobber())
+            this.configuration = new ConfigurationBuilder()
+                .AddDotNetEnvMulti(new[] { "./.env", "./.env2" }, LoadOptions.NoEnvVars().NoClobber())
                 .Build();
 
-            Assert.Equal("Toni", config["NAME"]);
+            Assert.Equal("Toni", this.configuration["NAME"]);
         }
 
         [Fact]
         public void AddSourceToBuilderAndFileDoesNotExist()
         {
-            var config = new ConfigurationBuilder()
-                .AddDotNetEnv("./.env_DNE")
+            this.configuration = new ConfigurationBuilder()
+                .AddDotNetEnv("./.env_DNE", LoadOptions.NoEnvVars())
                 .Build();
 
-            Assert.Empty(config.AsEnumerable());
+            Assert.Empty(this.configuration.AsEnumerable());
         }
 
         [Fact]
         public void AddSourceToBuilderAndGetSection()
         {
-            var config = new ConfigurationBuilder()
-                .AddDotNetEnv("./.env_sections")
+            this.configuration = new ConfigurationBuilder()
+                .AddDotNetEnv("./.env_sections", LoadOptions.NoEnvVars())
                 .Build();
 
-            var section = config.GetSection("SECTION");
+            var section = this.configuration.GetSection("SECTION");
 
             Assert.Equal("value1", section["Key1"]);
             Assert.Equal("value2", section["Key2"]);
+        }
+
+        [Fact()]
+        public void AddSourceToBuilderAndParseInterpolatedTest()
+        {
+            Environment.SetEnvironmentVariable("EXISTING_ENVIRONMENT_VARIABLE", "value");
+            Environment.SetEnvironmentVariable("DNE_VAR", null);
+
+            // Have to remove since it's recursive and can be set by the `EnvTests.cs`
+            Environment.SetEnvironmentVariable("TEST4", null);
+
+            this.configuration = new ConfigurationBuilder()
+                .AddDotNetEnv("./.env_embedded")
+                .Build();
+
+            Assert.Equal("test", this.configuration["TEST"]);
+            Assert.Equal("test1", this.configuration["TEST1"]);
+            Assert.Equal("test", this.configuration["TEST2"]);
+            Assert.Equal("testtest", this.configuration["TEST3"]);
+            Assert.Equal("testtest1", this.configuration["TEST4"]);
+
+            Assert.Equal("test:testtest1 $$ '\" ® and test1", this.configuration["TEST5_DOUBLE"]);
+            Assert.Equal("$TEST:$TEST4 \\$\\$ \" \\uae and $TEST1", this.configuration["TEST5_SINGLE"]);
+            Assert.Equal("test:testtest1\\uaeandtest1", this.configuration["TEST5_UNQUOTED"]);
+
+            Assert.Equal("value1", this.configuration["FIRST_KEY"]);
+            Assert.Equal("value2andvalue1", this.configuration["SECOND_KEY"]);
+            // EXISTING_ENVIRONMENT_VARIABLE already set to "value"
+            Assert.Equal("value;andvalue3", this.configuration["THIRD_KEY"]);
+            // DNE_VAR does not exist (has no value)
+            Assert.Equal(";nope", this.configuration["FOURTH_KEY"]);
+
+            Assert.Equal("^((?!Everyone).)*$", this.configuration["GROUP_FILTER_REGEX"]);
+
+            Assert.Equal("value$", this.configuration["DOLLAR1_U"]);
+            Assert.Equal("valuevalue$$", this.configuration["DOLLAR2_U"]);
+            Assert.Equal("value$.$", this.configuration["DOLLAR3_U"]);
+            Assert.Equal("value$$", this.configuration["DOLLAR4_U"]);
+
+            Assert.Equal("value$", this.configuration["DOLLAR1_S"]);
+            Assert.Equal("value$DOLLAR1_S$", this.configuration["DOLLAR2_S"]);
+            Assert.Equal("value$.$", this.configuration["DOLLAR3_S"]);
+            Assert.Equal("value$$", this.configuration["DOLLAR4_S"]);
+
+            Assert.Equal("value$", this.configuration["DOLLAR1_D"]);
+            Assert.Equal("valuevalue$$", this.configuration["DOLLAR2_D"]);
+            Assert.Equal("value$.$", this.configuration["DOLLAR3_D"]);
+            Assert.Equal("value$$", this.configuration["DOLLAR4_D"]);
         }
     }
 }

--- a/test/DotNetEnv.Tests/EnvConfigurationTests.cs
+++ b/test/DotNetEnv.Tests/EnvConfigurationTests.cs
@@ -66,5 +66,18 @@ namespace DotNetEnv.Tests
 
             Assert.Empty(config.AsEnumerable());
         }
+
+        [Fact]
+        public void AddSourceToBuilderAndGetSection()
+        {
+            var config = new ConfigurationBuilder()
+                .AddDotNetEnv("./.env_sections")
+                .Build();
+
+            var section = config.GetSection("SECTION");
+
+            Assert.Equal("value1", section["Key1"]);
+            Assert.Equal("value2", section["Key2"]);
+        }
     }
 }

--- a/test/DotNetEnv.Tests/xunit.runner.json
+++ b/test/DotNetEnv.Tests/xunit.runner.json
@@ -1,0 +1,3 @@
+﻿{
+    "parallelizeTestCollections": false
+}


### PR DESCRIPTION
Hello!

My colleague is super in love with your lib and it's great! I wanted to get it working with the .NET ConfigurationBuilder, so here's a small PR that wraps everything needed for it to work, including unit tests!

I put it in the same projet, which adds two references to `Microsoft.Extensions.Configuration` and `Microsoft.Extensions.Configuration.Abstractions`. It could also be split in a different project and packaged separately if you think it's too many deps that won't be used! (although they are included in most new projects by Visual Studio!)

README was updated!

Comments EXPECTED! :D