### PR TITLE
Fix/#68 CVE 2019 0820

### DIFF
--- a/src/DotNetEnv/DotNetEnv.csproj
+++ b/src/DotNetEnv/DotNetEnv.csproj
@@ -24,5 +24,6 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="1.1.2" />
     <PackageReference Include="Sprache" Version="2.3.1" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 </Project>

--- a/src/DotNetEnv/DotNetEnv.csproj
+++ b/src/DotNetEnv/DotNetEnv.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="1.1.2" />
     <PackageReference Include="Sprache" Version="2.3.1" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 </Project>

--- a/test/DotNetEnv.Tests/DotNetEnv.Tests.csproj
+++ b/test/DotNetEnv.Tests/DotNetEnv.Tests.csproj
@@ -42,7 +42,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Sprache" Version="2.3.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />

--- a/test/DotNetEnv.Tests/DotNetEnv.Tests.csproj
+++ b/test/DotNetEnv.Tests/DotNetEnv.Tests.csproj
@@ -44,6 +44,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
     <PackageReference Include="Sprache" Version="2.3.1" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>

--- a/test/DotNetEnv.Tests/DotNetEnv.Tests.csproj
+++ b/test/DotNetEnv.Tests/DotNetEnv.Tests.csproj
@@ -46,8 +46,8 @@
     <PackageReference Include="Sprache" Version="2.3.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/DotNetEnv.Tests/DotNetEnv.Tests.csproj
+++ b/test/DotNetEnv.Tests/DotNetEnv.Tests.csproj
@@ -42,7 +42,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Sprache" Version="2.3.1" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/test/DotNetEnv.Tests/DotNetEnv.Tests.csproj
+++ b/test/DotNetEnv.Tests/DotNetEnv.Tests.csproj
@@ -44,6 +44,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Sprache" Version="2.3.1" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />

--- a/test/DotNetEnvTraverse.Tests/DotNetEnvTraverse.Tests.csproj
+++ b/test/DotNetEnvTraverse.Tests/DotNetEnvTraverse.Tests.csproj
@@ -9,8 +9,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
   </ItemGroup>
 

--- a/test/DotNetEnvTraverse.Tests/DotNetEnvTraverse.Tests.csproj
+++ b/test/DotNetEnvTraverse.Tests/DotNetEnvTraverse.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/test/DotNetEnvTraverse.Tests/DotNetEnvTraverse.Tests.csproj
+++ b/test/DotNetEnvTraverse.Tests/DotNetEnvTraverse.Tests.csproj
@@ -10,8 +10,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
   </ItemGroup>
 

--- a/test/DotNetEnvTraverse.Tests/DotNetEnvTraverse.Tests.csproj
+++ b/test/DotNetEnvTraverse.Tests/DotNetEnvTraverse.Tests.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />

--- a/test/DotNetEnvTraverse.Tests/DotNetEnvTraverse.Tests.csproj
+++ b/test/DotNetEnvTraverse.Tests/DotNetEnvTraverse.Tests.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />


### PR DESCRIPTION
I think it is possible to resolve #68 by using System.Text.RegularExpressions 4.3.1 via explicit import.

Looking through package management I consolidated package versions in test projects too.
