### PR TITLE
Revert "remove all the unnecessary .End()s"

### DIFF
--- a/test/DotNetEnv.Tests/ParserTests.cs
+++ b/test/DotNetEnv.Tests/ParserTests.cs
@@ -44,14 +44,14 @@ namespace DotNetEnv.Tests
         [Fact]
         public void ParseIdentifier ()
         {
-            Assert.Equal("name", Parsers.Identifier.Parse("name"));
-            Assert.Equal("_n", Parsers.Identifier.Parse("_n"));
-            Assert.Equal("__", Parsers.Identifier.Parse("__"));
-            Assert.Equal("_0", Parsers.Identifier.Parse("_0"));
-            Assert.Equal("a_b", Parsers.Identifier.Parse("a_b"));
-            Assert.Equal("_a_b", Parsers.Identifier.Parse("_a_b"));
-            Assert.Equal("a.b", Parsers.Identifier.Parse("a.b"));
-            Assert.Equal("a-b", Parsers.Identifier.Parse("a-b"));
+            Assert.Equal("name", Parsers.Identifier.End().Parse("name"));
+            Assert.Equal("_n", Parsers.Identifier.End().Parse("_n"));
+            Assert.Equal("__", Parsers.Identifier.End().Parse("__"));
+            Assert.Equal("_0", Parsers.Identifier.End().Parse("_0"));
+            Assert.Equal("a_b", Parsers.Identifier.End().Parse("a_b"));
+            Assert.Equal("_a_b", Parsers.Identifier.End().Parse("_a_b"));
+            Assert.Equal("a.b", Parsers.Identifier.End().Parse("a.b"));
+            Assert.Equal("a-b", Parsers.Identifier.End().Parse("a-b"));
             Assert.Throws<ParseException>(() => Parsers.Identifier.End().Parse("\"name"));
             Assert.Throws<ParseException>(() => Parsers.Identifier.End().Parse("0name"));
             Assert.Throws<ParseException>(() => Parsers.Identifier.End().Parse(".a.b"));
@@ -64,21 +64,21 @@ namespace DotNetEnv.Tests
         [Fact]
         public void ParseOctalByte ()
         {
-            Assert.Equal(33, Parsers.OctalByte.Parse(@"\41"));
-            Assert.Equal(33, Parsers.OctalByte.Parse(@"\041"));
-            Assert.Equal(90, Parsers.OctalByte.Parse(@"\132"));
+            Assert.Equal(33, Parsers.OctalByte.End().Parse(@"\41"));
+            Assert.Equal(33, Parsers.OctalByte.End().Parse(@"\041"));
+            Assert.Equal(90, Parsers.OctalByte.End().Parse(@"\132"));
 
             // NOTE that bash accepts values outside of ASCII range?
             // printf "\412"
-            //Assert.Equal(???, Parsers.OctalChar.Parse(@"\412"));
+            //Assert.Equal(???, Parsers.OctalChar.End().Parse(@"\412"));
         }
 
         [Fact]
         public void ParseOctalChar ()
         {
-            Assert.Equal("!", Parsers.OctalChar.Parse(@"\41"));
-            Assert.Equal("!", Parsers.OctalChar.Parse(@"\041"));
-            Assert.Equal("Z", Parsers.OctalChar.Parse(@"\132"));
+            Assert.Equal("!", Parsers.OctalChar.End().Parse(@"\41"));
+            Assert.Equal("!", Parsers.OctalChar.End().Parse(@"\041"));
+            Assert.Equal("Z", Parsers.OctalChar.End().Parse(@"\132"));
 
             // as above for values outside of ASCII range
 
@@ -88,7 +88,7 @@ namespace DotNetEnv.Tests
         [Fact]
         public void ParseHexByte ()
         {
-            Assert.Equal(90, Parsers.HexByte.Parse(@"\x5a"));
+            Assert.Equal(90, Parsers.HexByte.End().Parse(@"\x5a"));
         }
 
         [Fact]
@@ -98,23 +98,23 @@ namespace DotNetEnv.Tests
             // printf '\xE2\x98\xA0'
             // printf ☠ | hexdump  # hexdump has bytes flipped per word (2 bytes, 4 hex)
 
-            Assert.Equal("Z", Parsers.Utf8Char.Parse(@"\x5A"));
-            Assert.Equal("®", Parsers.Utf8Char.Parse(@"\xc2\xae"));
-            Assert.Equal("☠", Parsers.Utf8Char.Parse(@"\xE2\x98\xA0"));
-            Assert.Equal(RocketChar, Parsers.Utf8Char.Parse(@"\xF0\x9F\x9A\x80"));
+            Assert.Equal("Z", Parsers.Utf8Char.End().Parse(@"\x5A"));
+            Assert.Equal("®", Parsers.Utf8Char.End().Parse(@"\xc2\xae"));
+            Assert.Equal("☠", Parsers.Utf8Char.End().Parse(@"\xE2\x98\xA0"));
+            Assert.Equal(RocketChar, Parsers.Utf8Char.End().Parse(@"\xF0\x9F\x9A\x80"));
 
             Assert.Equal(
                 "日本",
-                Parsers.Utf8Char.Parse(@"\xe6\x97\xa5")
-                    + Parsers.Utf8Char.Parse(@"\xe6\x9c\xac")
+                Parsers.Utf8Char.End().Parse(@"\xe6\x97\xa5")
+                    + Parsers.Utf8Char.End().Parse(@"\xe6\x9c\xac")
             );
         }
 
         [Fact]
         public void ParseUtf16Char ()
         {
-            Assert.Equal("®", Parsers.Utf16Char.Parse(@"\u00ae"));
-            Assert.Equal("®", Parsers.Utf16Char.Parse(@"\uae"));
+            Assert.Equal("®", Parsers.Utf16Char.End().Parse(@"\u00ae"));
+            Assert.Equal("®", Parsers.Utf16Char.End().Parse(@"\uae"));
 
             Assert.Equal("®", Encoding.Unicode.GetString(new byte[] { 0xae, 0x00 }));
         }
@@ -122,8 +122,8 @@ namespace DotNetEnv.Tests
         [Fact]
         public void ParseUtf32Char ()
         {
-            Assert.Equal(RocketChar, Parsers.Utf32Char.Parse(@"\U0001F680"));
-            Assert.Equal(RocketChar, Parsers.Utf32Char.Parse(@"\U1F680"));
+            Assert.Equal(RocketChar, Parsers.Utf32Char.End().Parse(@"\U0001F680"));
+            Assert.Equal(RocketChar, Parsers.Utf32Char.End().Parse(@"\U1F680"));
 
             Assert.Equal(RocketChar, Encoding.UTF32.GetString(new byte[] { 0x80, 0xf6, 0x01, 0x00 }));
             Assert.Equal(RocketChar, Encoding.UTF32.GetString(new byte[] { 0x80, 0xf6, 0x1, 0x0 }));
@@ -132,32 +132,32 @@ namespace DotNetEnv.Tests
         [Fact]
         public void ParseEscapedChar ()
         {
-            Assert.Equal("\b", Parsers.EscapedChar.Parse("\\b"));
-            Assert.Equal("'", Parsers.EscapedChar.Parse("\\'"));
-            Assert.Equal("\"", Parsers.EscapedChar.Parse("\\\""));
+            Assert.Equal("\b", Parsers.EscapedChar.End().Parse("\\b"));
+            Assert.Equal("'", Parsers.EscapedChar.End().Parse("\\'"));
+            Assert.Equal("\"", Parsers.EscapedChar.End().Parse("\\\""));
             Assert.Throws<ParseException>(() => Parsers.EscapedChar.End().Parse("\n"));
         }
 
         [Fact]
         public void ParseInterpolatedEnvVar ()
         {
-            Assert.Equal("ENV value", Parsers.InterpolatedEnvVar.Parse("$ENVVAR_TEST").GetValue());
-            Assert.Equal("ENV value", Parsers.InterpolatedBracesEnvVar.Parse("${ENVVAR_TEST}").GetValue());
+            Assert.Equal("ENV value", Parsers.InterpolatedEnvVar.End().Parse("$ENVVAR_TEST").GetValue());
+            Assert.Equal("ENV value", Parsers.InterpolatedBracesEnvVar.End().Parse("${ENVVAR_TEST}").GetValue());
         }
 
         [Fact]
         public void ParseInterpolated ()
         {
-            Assert.Equal("ENV value", Parsers.InterpolatedValue.Parse("$ENVVAR_TEST").GetValue());
-            Assert.Equal("ENV value", Parsers.InterpolatedValue.Parse("${ENVVAR_TEST}").GetValue());
-            Assert.Equal("", Parsers.InterpolatedValue.Parse("${ENVVAR_TEST_DNE}").GetValue());
+            Assert.Equal("ENV value", Parsers.InterpolatedValue.End().Parse("$ENVVAR_TEST").GetValue());
+            Assert.Equal("ENV value", Parsers.InterpolatedValue.End().Parse("${ENVVAR_TEST}").GetValue());
+            Assert.Equal("", Parsers.InterpolatedValue.End().Parse("${ENVVAR_TEST_DNE}").GetValue());
         }
 
         [Fact]
         public void ParseNotControlNorWhitespace ()
         {
-            Assert.Equal("a", Parsers.NotControlNorWhitespace(EXCEPT_CHARS).Parse("a"));
-            Assert.Equal("%", Parsers.NotControlNorWhitespace(EXCEPT_CHARS).Parse("%"));
+            Assert.Equal("a", Parsers.NotControlNorWhitespace(EXCEPT_CHARS).End().Parse("a"));
+            Assert.Equal("%", Parsers.NotControlNorWhitespace(EXCEPT_CHARS).End().Parse("%"));
             Assert.Throws<ParseException>(() => Parsers.NotControlNorWhitespace(EXCEPT_CHARS).End().Parse(" "));
             Assert.Throws<ParseException>(() => Parsers.NotControlNorWhitespace(EXCEPT_CHARS).End().Parse("\n"));
             Assert.Throws<ParseException>(() => Parsers.NotControlNorWhitespace(EXCEPT_CHARS).End().Parse("'"));
@@ -168,33 +168,33 @@ namespace DotNetEnv.Tests
         [Fact]
         public void ParseSpecialChar ()
         {
-            Assert.Equal("Z", Parsers.SpecialChar.Parse(@"\x5A"));
-            Assert.Equal("®", Parsers.SpecialChar.Parse(@"\xc2\xae"));
-            Assert.Equal("☠", Parsers.SpecialChar.Parse(@"\xE2\x98\xA0"));
-            Assert.Equal(RocketChar, Parsers.SpecialChar.Parse(@"\xF0\x9F\x9A\x80"));
+            Assert.Equal("Z", Parsers.SpecialChar.End().Parse(@"\x5A"));
+            Assert.Equal("®", Parsers.SpecialChar.End().Parse(@"\xc2\xae"));
+            Assert.Equal("☠", Parsers.SpecialChar.End().Parse(@"\xE2\x98\xA0"));
+            Assert.Equal(RocketChar, Parsers.SpecialChar.End().Parse(@"\xF0\x9F\x9A\x80"));
             Assert.Equal(
                 "日本",
-                Parsers.SpecialChar.Parse(@"\xe6\x97\xa5")
-                    + Parsers.SpecialChar.Parse(@"\xe6\x9c\xac")
+                Parsers.SpecialChar.End().Parse(@"\xe6\x97\xa5")
+                    + Parsers.SpecialChar.End().Parse(@"\xe6\x9c\xac")
             );
 
-            Assert.Equal("®", Parsers.SpecialChar.Parse(@"\u00ae"));
-            Assert.Equal("®", Parsers.SpecialChar.Parse(@"\uae"));
+            Assert.Equal("®", Parsers.SpecialChar.End().Parse(@"\u00ae"));
+            Assert.Equal("®", Parsers.SpecialChar.End().Parse(@"\uae"));
 
-            Assert.Equal(RocketChar, Parsers.SpecialChar.Parse(@"\U0001F680"));
-            Assert.Equal(RocketChar, Parsers.SpecialChar.Parse(@"\U1F680"));
+            Assert.Equal(RocketChar, Parsers.SpecialChar.End().Parse(@"\U0001F680"));
+            Assert.Equal(RocketChar, Parsers.SpecialChar.End().Parse(@"\U1F680"));
 
-            Assert.Equal("\b", Parsers.SpecialChar.Parse("\\b"));
-            Assert.Equal("\\m", Parsers.SpecialChar.Parse("\\m"));
-            Assert.Equal("'", Parsers.SpecialChar.Parse("\\'"));
-            Assert.Equal("\"", Parsers.SpecialChar.Parse("\\\""));
+            Assert.Equal("\b", Parsers.SpecialChar.End().Parse("\\b"));
+            Assert.Equal("\\m", Parsers.SpecialChar.End().Parse("\\m"));
+            Assert.Equal("'", Parsers.SpecialChar.End().Parse("\\'"));
+            Assert.Equal("\"", Parsers.SpecialChar.End().Parse("\\\""));
 
             // this caught a bug, once upon a time, where backslashes were
             // getting processed by NCNW rather than EscapedChar inside SpecialChar
             var parser = Parsers.SpecialChar
                 .Or(Parsers.NotControlNorWhitespace("\"$"))
                 .Or(Parse.WhiteSpace.AtLeastOnce().Text());
-            Assert.Equal("\"", parser.Parse("\\\""));
+            Assert.Equal("\"", parser.End().Parse("\\\""));
 
             Assert.Throws<ParseException>(() => Parsers.SpecialChar.End().Parse("a"));
             Assert.Throws<ParseException>(() => Parsers.SpecialChar.End().Parse("%"));
@@ -205,9 +205,9 @@ namespace DotNetEnv.Tests
         [Fact]
         public void ParseComment ()
         {
-            Assert.Equal(" comment 1", Parsers.Comment.Parse("# comment 1"));
-            Assert.Equal("", Parsers.Comment.Parse("#"));
-            Assert.Equal(" ", Parsers.Comment.Parse("# "));
+            Assert.Equal(" comment 1", Parsers.Comment.End().Parse("# comment 1"));
+            Assert.Equal("", Parsers.Comment.End().Parse("#"));
+            Assert.Equal(" ", Parsers.Comment.End().Parse("# "));
         }
 
         [Fact]
@@ -215,74 +215,74 @@ namespace DotNetEnv.Tests
         {
             var kvp = new KeyValuePair<string, string>(null, null);
 
-            Assert.Equal(kvp, Parsers.Empty.Parse("# comment 1"));
-            Assert.Equal(kvp, Parsers.Empty.Parse("# comment 2\r\n"));
-            Assert.Equal(kvp, Parsers.Empty.Parse("# comment 3\n"));
+            Assert.Equal(kvp, Parsers.Empty.End().Parse("# comment 1"));
+            Assert.Equal(kvp, Parsers.Empty.End().Parse("# comment 2\r\n"));
+            Assert.Equal(kvp, Parsers.Empty.End().Parse("# comment 3\n"));
 
-            Assert.Equal(kvp, Parsers.Empty.Parse(""));
-            Assert.Equal(kvp, Parsers.Empty.Parse("\r\n"));
-            Assert.Equal(kvp, Parsers.Empty.Parse("\n"));
+            Assert.Equal(kvp, Parsers.Empty.End().Parse(""));
+            Assert.Equal(kvp, Parsers.Empty.End().Parse("\r\n"));
+            Assert.Equal(kvp, Parsers.Empty.End().Parse("\n"));
 
-            Assert.Equal(kvp, Parsers.Empty.Parse("   # comment 1"));
-            Assert.Equal(kvp, Parsers.Empty.Parse("    \r\n"));
-            Assert.Equal(kvp, Parsers.Empty.Parse("#export EV_DNE=\"\\xe6\\x97\\xa5 $ENVVAR_TEST 本\"#ccccc\n"));
+            Assert.Equal(kvp, Parsers.Empty.End().Parse("   # comment 1"));
+            Assert.Equal(kvp, Parsers.Empty.End().Parse("    \r\n"));
+            Assert.Equal(kvp, Parsers.Empty.End().Parse("#export EV_DNE=\"\\xe6\\x97\\xa5 $ENVVAR_TEST 本\"#ccccc\n"));
         }
 
         [Fact]
         public void ParseUnquotedValue ()
         {
-            Assert.Equal("abc", Parsers.UnquotedValue.Parse("abc").Value);
-            Assert.Equal("a b c", Parsers.UnquotedValue.Parse("a b c").Value);
-            Assert.Equal("041", Parsers.UnquotedValue.Parse("041").Value);
-            Assert.Equal("日本", Parsers.UnquotedValue.Parse("日本").Value);
+            Assert.Equal("abc", Parsers.UnquotedValue.End().Parse("abc").Value);
+            Assert.Equal("a b c", Parsers.UnquotedValue.End().Parse("a b c").Value);
+            Assert.Equal("041", Parsers.UnquotedValue.End().Parse("041").Value);
+            Assert.Equal("日本", Parsers.UnquotedValue.End().Parse("日本").Value);
             // TODO: is it possible to get the system to recognize when a complete unicode char is present and start the next one then, without a space?
 //            Assert.Equal("日本", Parsers.UnquotedValue.Parse(@"\xe6\x97\xa5\xe6\x9c\xac"));
 
             Assert.Throws<ParseException>(() => Parsers.UnquotedValue.End().Parse("0\n1"));
             Assert.Throws<ParseException>(() => Parsers.UnquotedValue.End().Parse("'"));
 
-            Assert.Equal("a\\?b", Parsers.UnquotedValue.Parse("a\\?b").Value);
-            Assert.Equal(@"\xe6\x97\xa5ENV value本", Parsers.UnquotedValue.Parse("\\xe6\\x97\\xa5${ENVVAR_TEST}本").Value);
+            Assert.Equal("a\\?b", Parsers.UnquotedValue.End().Parse("a\\?b").Value);
+            Assert.Equal(@"\xe6\x97\xa5ENV value本", Parsers.UnquotedValue.End().Parse("\\xe6\\x97\\xa5${ENVVAR_TEST}本").Value);
         }
 
         [Fact]
         public void ParseDoubleQuotedValueContents ()
         {
-            Assert.Equal("abc", Parsers.DoubleQuotedValueContents.Parse("abc").Value);
-            Assert.Equal("a b c", Parsers.DoubleQuotedValueContents.Parse("a b c").Value);
-            Assert.Equal("0\n1", Parsers.DoubleQuotedValueContents.Parse("0\n1").Value);
-            Assert.Equal("日 本", Parsers.DoubleQuotedValueContents.Parse(@"\xe6\x97\xa5 \xe6\x9c\xac").Value);
-            Assert.Equal("☠ ®", Parsers.DoubleQuotedValueContents.Parse(@"\xE2\x98\xA0 \uae").Value);
+            Assert.Equal("abc", Parsers.DoubleQuotedValueContents.End().Parse("abc").Value);
+            Assert.Equal("a b c", Parsers.DoubleQuotedValueContents.End().Parse("a b c").Value);
+            Assert.Equal("0\n1", Parsers.DoubleQuotedValueContents.End().Parse("0\n1").Value);
+            Assert.Equal("日 本", Parsers.DoubleQuotedValueContents.End().Parse(@"\xe6\x97\xa5 \xe6\x9c\xac").Value);
+            Assert.Equal("☠ ®", Parsers.DoubleQuotedValueContents.End().Parse(@"\xE2\x98\xA0 \uae").Value);
 
-            Assert.Equal("日 ENV value 本", Parsers.DoubleQuotedValueContents.Parse("\\xe6\\x97\\xa5 $ENVVAR_TEST 本").Value);
+            Assert.Equal("日 ENV value 本", Parsers.DoubleQuotedValueContents.End().Parse("\\xe6\\x97\\xa5 $ENVVAR_TEST 本").Value);
 
-            Assert.Equal("a\"b c", Parsers.DoubleQuotedValueContents.Parse("a\\\"b c").Value);
-            Assert.Equal("a'b c", Parsers.DoubleQuotedValueContents.Parse("a'b c").Value);
+            Assert.Equal("a\"b c", Parsers.DoubleQuotedValueContents.End().Parse("a\\\"b c").Value);
+            Assert.Equal("a'b c", Parsers.DoubleQuotedValueContents.End().Parse("a'b c").Value);
         }
 
         [Fact]
         public void ParseSingleQuotedValueContents ()
         {
-            Assert.Equal("abc", Parsers.SingleQuotedValueContents.Parse("abc").Value);
-            Assert.Equal("a b c", Parsers.SingleQuotedValueContents.Parse("a b c").Value);
-            Assert.Equal("0\n1", Parsers.SingleQuotedValueContents.Parse("0\n1").Value);
-            Assert.Equal(@"\xe6\x97\xa5 \xe6\x9c\xac", Parsers.SingleQuotedValueContents.Parse(@"\xe6\x97\xa5 \xe6\x9c\xac").Value);
-            Assert.Equal(@"\xE2\x98\xA0 \uae", Parsers.SingleQuotedValueContents.Parse(@"\xE2\x98\xA0 \uae").Value);
+            Assert.Equal("abc", Parsers.SingleQuotedValueContents.End().Parse("abc").Value);
+            Assert.Equal("a b c", Parsers.SingleQuotedValueContents.End().Parse("a b c").Value);
+            Assert.Equal("0\n1", Parsers.SingleQuotedValueContents.End().Parse("0\n1").Value);
+            Assert.Equal(@"\xe6\x97\xa5 \xe6\x9c\xac", Parsers.SingleQuotedValueContents.End().Parse(@"\xe6\x97\xa5 \xe6\x9c\xac").Value);
+            Assert.Equal(@"\xE2\x98\xA0 \uae", Parsers.SingleQuotedValueContents.End().Parse(@"\xE2\x98\xA0 \uae").Value);
 
-            Assert.Equal("\\xe6\\x97\\xa5 $ENVVAR_TEST 本", Parsers.SingleQuotedValueContents.Parse("\\xe6\\x97\\xa5 $ENVVAR_TEST 本").Value);
+            Assert.Equal("\\xe6\\x97\\xa5 $ENVVAR_TEST 本", Parsers.SingleQuotedValueContents.End().Parse("\\xe6\\x97\\xa5 $ENVVAR_TEST 本").Value);
 
-            Assert.Equal("a\"b c", Parsers.SingleQuotedValueContents.Parse("a\"b c").Value);
+            Assert.Equal("a\"b c", Parsers.SingleQuotedValueContents.End().Parse("a\"b c").Value);
         }
 
         [Fact]
         public void ParseSingleQuotedValue ()
         {
-            Assert.Equal("abc", Parsers.SingleQuotedValue.Parse("'abc'").Value);
-            Assert.Equal("a b c", Parsers.SingleQuotedValue.Parse("'a b c'").Value);
-            Assert.Equal("0\n1", Parsers.SingleQuotedValue.Parse("'0\n1'").Value);
-            Assert.Equal("a\"bc", Parsers.SingleQuotedValue.Parse("'a\"bc'").Value);
+            Assert.Equal("abc", Parsers.SingleQuotedValue.End().Parse("'abc'").Value);
+            Assert.Equal("a b c", Parsers.SingleQuotedValue.End().Parse("'a b c'").Value);
+            Assert.Equal("0\n1", Parsers.SingleQuotedValue.End().Parse("'0\n1'").Value);
+            Assert.Equal("a\"bc", Parsers.SingleQuotedValue.End().Parse("'a\"bc'").Value);
 
-            Assert.Equal("\\xe6\\x97\\xa5 $ENVVAR_TEST 本", Parsers.SingleQuotedValue.Parse("'\\xe6\\x97\\xa5 $ENVVAR_TEST 本'").Value);
+            Assert.Equal("\\xe6\\x97\\xa5 $ENVVAR_TEST 本", Parsers.SingleQuotedValue.End().Parse("'\\xe6\\x97\\xa5 $ENVVAR_TEST 本'").Value);
 
             Assert.Throws<ParseException>(() => Parsers.SingleQuotedValue.End().Parse("'a\\'b c'").Value);
         }
@@ -290,44 +290,44 @@ namespace DotNetEnv.Tests
         [Fact]
         public void ParseDoubleQuotedValue ()
         {
-            Assert.Equal("abc", Parsers.DoubleQuotedValue.Parse("\"abc\"").Value);
-            Assert.Equal("a b c", Parsers.DoubleQuotedValue.Parse("\"a b c\"").Value);
-            Assert.Equal("0\n1", Parsers.DoubleQuotedValue.Parse("\"0\n1\"").Value);
-            Assert.Equal("a'bc", Parsers.DoubleQuotedValue.Parse("\"a'bc\"").Value);
-            Assert.Equal("a\"bc", Parsers.DoubleQuotedValue.Parse("\"a\\\"bc\"").Value);
+            Assert.Equal("abc", Parsers.DoubleQuotedValue.End().Parse("\"abc\"").Value);
+            Assert.Equal("a b c", Parsers.DoubleQuotedValue.End().Parse("\"a b c\"").Value);
+            Assert.Equal("0\n1", Parsers.DoubleQuotedValue.End().Parse("\"0\n1\"").Value);
+            Assert.Equal("a'bc", Parsers.DoubleQuotedValue.End().Parse("\"a'bc\"").Value);
+            Assert.Equal("a\"bc", Parsers.DoubleQuotedValue.End().Parse("\"a\\\"bc\"").Value);
 
-            Assert.Equal("日 ENV value 本", Parsers.DoubleQuotedValue.Parse("\"\\xe6\\x97\\xa5 $ENVVAR_TEST 本\"").Value);
+            Assert.Equal("日 ENV value 本", Parsers.DoubleQuotedValue.End().Parse("\"\\xe6\\x97\\xa5 $ENVVAR_TEST 本\"").Value);
         }
 
         [Fact]
         public void ParseValue ()
         {
-            Assert.Equal("abc", Parsers.Value.Parse("abc").Value);
-            Assert.Equal("a b c", Parsers.Value.Parse("a b c").Value);
-            Assert.Equal("041", Parsers.Value.Parse("041").Value);
-            Assert.Equal("日本", Parsers.Value.Parse("日本").Value);
+            Assert.Equal("abc", Parsers.Value.End().Parse("abc").Value);
+            Assert.Equal("a b c", Parsers.Value.End().Parse("a b c").Value);
+            Assert.Equal("041", Parsers.Value.End().Parse("041").Value);
+            Assert.Equal("日本", Parsers.Value.End().Parse("日本").Value);
             // TODO: is it possible to get the system to recognize when a complete unicode char is present and start the next one then, without a space?
-//            Assert.Equal("日本", Parsers.Value.Parse(@"\xe6\x97\xa5\xe6\x9c\xac"));
+//            Assert.Equal("日本", Parsers.Value.End().Parse(@"\xe6\x97\xa5\xe6\x9c\xac"));
 
             Assert.Throws<ParseException>(() => Parsers.Value.End().Parse("0\n1"));
             Assert.Throws<ParseException>(() => Parsers.Value.End().Parse("'"));
 
-            Assert.Equal(@"\xe6\x97\xa5", Parsers.Value.Parse(@"\xe6\x97\xa5").Value);
-            Assert.Equal(@"\xE2\x98\xA0", Parsers.Value.Parse(@"\xE2\x98\xA0").Value);
+            Assert.Equal(@"\xe6\x97\xa5", Parsers.Value.End().Parse(@"\xe6\x97\xa5").Value);
+            Assert.Equal(@"\xE2\x98\xA0", Parsers.Value.End().Parse(@"\xE2\x98\xA0").Value);
 
-            Assert.Equal("abc", Parsers.Value.Parse("'abc'").Value);
-            Assert.Equal("a b c", Parsers.Value.Parse("'a b c'").Value);
-            Assert.Equal("0\n1", Parsers.Value.Parse("'0\n1'").Value);
-            Assert.Equal(@"\xe6\x97\xa5 \xe6\x9c\xac", Parsers.Value.Parse(@"'\xe6\x97\xa5 \xe6\x9c\xac'").Value);
-            Assert.Equal(@"\xE2\x98\xA0 \uae", Parsers.Value.Parse(@"'\xE2\x98\xA0 \uae'").Value);
+            Assert.Equal("abc", Parsers.Value.End().Parse("'abc'").Value);
+            Assert.Equal("a b c", Parsers.Value.End().Parse("'a b c'").Value);
+            Assert.Equal("0\n1", Parsers.Value.End().Parse("'0\n1'").Value);
+            Assert.Equal(@"\xe6\x97\xa5 \xe6\x9c\xac", Parsers.Value.End().Parse(@"'\xe6\x97\xa5 \xe6\x9c\xac'").Value);
+            Assert.Equal(@"\xE2\x98\xA0 \uae", Parsers.Value.End().Parse(@"'\xE2\x98\xA0 \uae'").Value);
 
-            Assert.Equal("abc", Parsers.Value.Parse("\"abc\"").Value);
-            Assert.Equal("a b c", Parsers.Value.Parse("\"a b c\"").Value);
-            Assert.Equal("0\n1", Parsers.Value.Parse("\"0\n1\"").Value);
-            Assert.Equal("日 本", Parsers.Value.Parse("\"\\xe6\\x97\\xa5 \\xe6\\x9c\\xac\"").Value);
-            Assert.Equal("☠ ®", Parsers.Value.Parse("\"\\xE2\\x98\\xA0 \\uae\"").Value);
+            Assert.Equal("abc", Parsers.Value.End().Parse("\"abc\"").Value);
+            Assert.Equal("a b c", Parsers.Value.End().Parse("\"a b c\"").Value);
+            Assert.Equal("0\n1", Parsers.Value.End().Parse("\"0\n1\"").Value);
+            Assert.Equal("日 本", Parsers.Value.End().Parse("\"\\xe6\\x97\\xa5 \\xe6\\x9c\\xac\"").Value);
+            Assert.Equal("☠ ®", Parsers.Value.End().Parse("\"\\xE2\\x98\\xA0 \\uae\"").Value);
 
-            Assert.Equal("日 ENV value 本", Parsers.Value.Parse("\"\\xe6\\x97\\xa5 $ENVVAR_TEST 本\"").Value);
+            Assert.Equal("日 ENV value 本", Parsers.Value.End().Parse("\"\\xe6\\x97\\xa5 $ENVVAR_TEST 本\"").Value);
         }
 
         [Fact]
@@ -335,7 +335,7 @@ namespace DotNetEnv.Tests
         {
             Action<string, string, string> testParse = (key, value, input) =>
             {
-                var kvp = Parsers.Assignment.Parse(input);
+                var kvp = Parsers.Assignment.End().Parse(input);
                 Assert.Equal(key, kvp.Key);
                 Assert.Equal(value, kvp.Value);
             };
@@ -349,14 +349,14 @@ namespace DotNetEnv.Tests
             testParse("EV_DNE", @"\xe6\x97\xa5 \xe6\x9c\xac", @"EV_DNE=\xe6\x97\xa5 \xe6\x9c\xac");
             testParse("EV_DNE", @"\xE2\x98\xA0 \uae", @"EV_DNE=\xE2\x98\xA0 \uae");
 
-            var kvp = Parsers.Assignment.Parse("EV_DNE=");
+            var kvp = Parsers.Assignment.End().Parse("EV_DNE=");
             Assert.Equal("EV_DNE", kvp.Key);
             Assert.Equal("", kvp.Value);
             // Note that dotnet returns null if the env var is empty -- even if it was set to empty!
             Assert.Null(Environment.GetEnvironmentVariable("EV_DNE"));
 
             // TODO: is it possible to get the system to recognize when a complete unicode char is present and start the next one then, without a space?
-//            Assert.Equal("EV_DNE=日本", Parsers.Assignment.Parse(@"EV_DNE=\xe6\x97\xa5\xe6\x9c\xac"));
+//            Assert.Equal("EV_DNE=日本", Parsers.Assignment.End().Parse(@"EV_DNE=\xe6\x97\xa5\xe6\x9c\xac"));
 
             Assert.Throws<ParseException>(() => Parsers.Assignment.End().Parse("EV_DNE='"));
             Assert.Throws<ParseException>(() => Parsers.Assignment.End().Parse("EV_DNE=0\n1"));


### PR DESCRIPTION
Reverts tonerdo/dotnet-env#85

Sigh, it's been too long since I last touched all of this.

The `.End()`s are necessary to assert the end of the string.