### PR TITLE
refactor/DictionaryExtension

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ null == System.Environment.GetEnvironmentVariable("KEY")
 "value" == kvps.First().Value
 ```
 
+With `CreateDictionaryOption` you can change behavior of `ToDotEnvDictionary` to take either the First value or to throw on duplicates. With the `TakeFirst` options you can simulate `NoClobber`-behavior.
+
 2. `clobberExistingVars`, second arg: `true` to always set env vars,
  `false` would leave existing env vars alone.
 

--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ All parameters default to true, which means:
 1. `setEnvVars`, first arg: `true` in order to actually update env vars.
  Setting it `false` allows consumers of this library to process the .env file
  but use it for things other than updating env vars, as a generic configuration file.
- The Load methods all return an `IEnumerable<KeyValuePair<string,string>> for this, but
- there is an extension method ToDictionary to get a dict with the last value for each key.
+ The Load methods all return an `IEnumerable<KeyValuePair<string,string>>` for this, but
+ there is an extension method `ToDictionary(CreateDictionaryOption.TakeLast)` to get a dict with the last value for each key.
 
 ```env
 KEY=value
@@ -118,7 +118,7 @@ var kvps = DotNetEnv.Env.Load(
 )
 
 // or the recommended, cleaner (fluent) approach:
-var dict = DotNetEnv.Env.NoEnvVars().Load().ToDictionary();
+var dict = DotNetEnv.Env.NoEnvVars().Load().ToDictionary(CreateDictionaryOption.TakeLast);
 
 // not "value" from the .env file
 null == System.Environment.GetEnvironmentVariable("KEY")

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ All parameters default to true, which means:
  Setting it `false` allows consumers of this library to process the .env file
  but use it for things other than updating env vars, as a generic configuration file.
  The Load methods all return an `IEnumerable<KeyValuePair<string,string>>` for this, but
- there is an extension method `ToDictionary(CreateDictionaryOption.TakeLast)` to get a dict with the last value for each key.
+ there is an extension method `ToDotEnvDictionary()` to get a dict with the last value for each key.
 
 ```env
 KEY=value
@@ -118,7 +118,7 @@ var kvps = DotNetEnv.Env.Load(
 )
 
 // or the recommended, cleaner (fluent) approach:
-var dict = DotNetEnv.Env.NoEnvVars().Load().ToDictionary(CreateDictionaryOption.TakeLast);
+var dict = DotNetEnv.Env.NoEnvVars().Load().ToDotEnvDictionary();
 
 // not "value" from the .env file
 null == System.Environment.GetEnvironmentVariable("KEY")

--- a/src/DotNetEnv/Configuration/EnvConfigurationProvider.cs
+++ b/src/DotNetEnv/Configuration/EnvConfigurationProvider.cs
@@ -38,7 +38,9 @@ namespace DotNetEnv.Configuration
             }
 
             // Since the Load method does not take care of cloberring, We have to check it here!
-            foreach (var value in values.ToDotEnvDictionary(options.ClobberExistingVars ? CreateDictionaryOption.TakeLast : CreateDictionaryOption.TakeFirst))
+            var dotEnvDictionary = values.ToDotEnvDictionary(options.ClobberExistingVars ? CreateDictionaryOption.TakeLast : CreateDictionaryOption.TakeFirst);
+
+            foreach (var value in dotEnvDictionary)
                 Data[NormalizeKey(value.Key)] = value.Value;
         }
 

--- a/src/DotNetEnv/Configuration/EnvConfigurationProvider.cs
+++ b/src/DotNetEnv/Configuration/EnvConfigurationProvider.cs
@@ -38,9 +38,8 @@ namespace DotNetEnv.Configuration
             }
 
             // Since the Load method does not take care of cloberring, We have to check it here!
-            var dotEnvDictionary = values.ToDotEnvDictionary(options.ClobberExistingVars ? CreateDictionaryOption.TakeLast : CreateDictionaryOption.TakeFirst);
-
-            foreach (var value in dotEnvDictionary)
+            var dictionaryOption = options.ClobberExistingVars ? CreateDictionaryOption.TakeLast : CreateDictionaryOption.TakeFirst;
+            foreach (var value in values.ToDotEnvDictionary(dictionaryOption))
                 Data[NormalizeKey(value.Key)] = value.Value;
         }
 

--- a/src/DotNetEnv/Configuration/EnvConfigurationProvider.cs
+++ b/src/DotNetEnv/Configuration/EnvConfigurationProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using DotNetEnv.Extensions;
 using Microsoft.Extensions.Configuration;
 
 namespace DotNetEnv.Configuration
@@ -37,22 +38,11 @@ namespace DotNetEnv.Configuration
             }
 
             // Since the Load method does not take care of cloberring, We have to check it here!
-            foreach (var value in values)
-            {
-                var key = NormalizeKey(value.Key);
-                if (this.options.ClobberExistingVars)
-                {
-                    this.Data[key] = value.Value;
-                }
-                else
-                {
-                    if (!this.Data.ContainsKey(key))
-                    {
-                        this.Data.Add(key, value.Value);
-                    }
-                }
-            }
+            foreach (var value in values.ToDotEnvDictionary(options.ClobberExistingVars ? CreateDictionaryOption.TakeLast : CreateDictionaryOption.TakeFirst))
+                Data[NormalizeKey(value.Key)] = value.Value;
         }
-        private static string NormalizeKey(string key) => key.Replace("__", ConfigurationPath.KeyDelimiter);
+
+        private static string NormalizeKey(string key)
+            => key.Replace("__", ConfigurationPath.KeyDelimiter);
     }
 }

--- a/src/DotNetEnv/Configuration/EnvConfigurationSource.cs
+++ b/src/DotNetEnv/Configuration/EnvConfigurationSource.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
 
 namespace DotNetEnv.Configuration
 {

--- a/src/DotNetEnv/Env.cs
+++ b/src/DotNetEnv/Env.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Text;
 
 namespace DotNetEnv
 {

--- a/src/DotNetEnv/Env.cs
+++ b/src/DotNetEnv/Env.cs
@@ -101,10 +101,4 @@ namespace DotNetEnv
         public static LoadOptions NoClobber () => LoadOptions.NoClobber();
         public static LoadOptions TraversePath () => LoadOptions.TraversePath();
     }
-
-    public static class Extensions
-    {
-        public static Dictionary<string, string> ToDictionary (this IEnumerable<KeyValuePair<string, string>> kvps) =>
-            kvps.GroupBy(kv => kv.Key).ToDictionary(g => g.Key, g => g.Last().Value);
-    }
 }

--- a/src/DotNetEnv/Extensions/CreateDictionaryOption.cs
+++ b/src/DotNetEnv/Extensions/CreateDictionaryOption.cs
@@ -1,19 +1,19 @@
-﻿namespace DotNetEnv.Extensions
+namespace DotNetEnv.Extensions
 {
     public enum CreateDictionaryOption
     {
         /// <summary>
-        /// Default behaviour, throws on duplicates.
+        /// Throws on duplicates.
         /// </summary>
-        Default,
+        Throw,
 
         /// <summary>
-        /// Takes the first occurrence for duplicates.
+        /// Takes the first occurrence on duplicates instead of throwing.
         /// </summary>
         TakeFirst,
 
         /// <summary>
-        /// Takes the last occurrence for duplicates.
+        /// Takes the last occurrence on duplicates instead of throwing.
         /// </summary>
         TakeLast,
     }

--- a/src/DotNetEnv/Extensions/CreateDictionaryOption.cs
+++ b/src/DotNetEnv/Extensions/CreateDictionaryOption.cs
@@ -1,0 +1,20 @@
+﻿namespace DotNetEnv.Extensions
+{
+    public enum CreateDictionaryOption
+    {
+        /// <summary>
+        /// Default behaviour, throws on duplicates.
+        /// </summary>
+        Default,
+
+        /// <summary>
+        /// Takes the first occurrence for duplicates.
+        /// </summary>
+        TakeFirst,
+
+        /// <summary>
+        /// Takes the last occurrence for duplicates.
+        /// </summary>
+        TakeLast,
+    }
+}

--- a/src/DotNetEnv/Extensions/LinqExtensions.cs
+++ b/src/DotNetEnv/Extensions/LinqExtensions.cs
@@ -6,16 +6,16 @@ namespace DotNetEnv.Extensions
 {
     public static class LinqExtensions
     {
-        public static Dictionary<string, string> ToDotEnvDictionary(this IEnumerable<KeyValuePair<string, string>> @this, CreateDictionaryOption option = CreateDictionaryOption.TakeLast)
+        public static Dictionary<string, string> ToDotEnvDictionary(this IEnumerable<KeyValuePair<string, string>> kvps, CreateDictionaryOption option = CreateDictionaryOption.TakeLast)
         {
             switch (option)
             {
                 case CreateDictionaryOption.Throw:
-                    return @this.ToDictionary(x => x.Key, x => x.Value);
+                    return kvps.ToDictionary(x => x.Key, x => x.Value);
                 case CreateDictionaryOption.TakeFirst:
-                    return @this.GroupBy(x => x.Key).ToDictionary(x => x.Key, x => x.First().Value);
+                    return kvps.GroupBy(x => x.Key).ToDictionary(x => x.Key, x => x.First().Value);
                 case CreateDictionaryOption.TakeLast:
-                    return @this.GroupBy(x => x.Key).ToDictionary(x => x.Key, x => x.Last().Value);
+                    return kvps.GroupBy(x => x.Key).ToDictionary(x => x.Key, x => x.Last().Value);
                 default:
                     throw new ArgumentOutOfRangeException(nameof(option), option, null);
             }

--- a/src/DotNetEnv/Extensions/LinqExtensions.cs
+++ b/src/DotNetEnv/Extensions/LinqExtensions.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DotNetEnv.Extensions
+{
+    public static class LinqExtensions
+    {
+        public static Dictionary<string, string> ToDictionary(this IEnumerable<KeyValuePair<string, string>> @this, CreateDictionaryOption option = CreateDictionaryOption.Default)
+        {
+            switch (option)
+            {
+                case CreateDictionaryOption.Default:
+                    return @this.ToDictionary(x => x.Key, x => x.Value);
+                case CreateDictionaryOption.TakeFirst:
+                    return @this.GroupBy(x => x.Key).ToDictionary(x => x.Key, x => x.First().Value);
+                case CreateDictionaryOption.TakeLast:
+                    return @this.GroupBy(x => x.Key).ToDictionary(x => x.Key, x => x.Last().Value);
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(option), option, null);
+            }
+        }
+    }
+}

--- a/src/DotNetEnv/Extensions/LinqExtensions.cs
+++ b/src/DotNetEnv/Extensions/LinqExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,11 +6,11 @@ namespace DotNetEnv.Extensions
 {
     public static class LinqExtensions
     {
-        public static Dictionary<string, string> ToDictionary(this IEnumerable<KeyValuePair<string, string>> @this, CreateDictionaryOption option = CreateDictionaryOption.Default)
+        public static Dictionary<string, string> ToDotEnvDictionary(this IEnumerable<KeyValuePair<string, string>> @this, CreateDictionaryOption option = CreateDictionaryOption.TakeLast)
         {
             switch (option)
             {
-                case CreateDictionaryOption.Default:
+                case CreateDictionaryOption.Throw:
                     return @this.ToDictionary(x => x.Key, x => x.Value);
                 case CreateDictionaryOption.TakeFirst:
                     return @this.GroupBy(x => x.Key).ToDictionary(x => x.Key, x => x.First().Value);

--- a/src/DotNetEnv/IEnvReader.cs
+++ b/src/DotNetEnv/IEnvReader.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Text;
 using static System.Environment;
 
 namespace DotNetEnv

--- a/src/DotNetEnv/LoadOptions.cs
+++ b/src/DotNetEnv/LoadOptions.cs
@@ -1,9 +1,4 @@
-using System;
-using System.Linq;
 using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Text;
 
 namespace DotNetEnv
 {

--- a/test/DotNetEnv.Tests/EnvTests.cs
+++ b/test/DotNetEnv.Tests/EnvTests.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.IO;
 using System.Runtime.InteropServices;
+using DotNetEnv.Extensions;
 using Xunit;
 using Sprache;
 
@@ -283,7 +284,7 @@ base64
 
             var kvps = DotNetEnv.Env.Load("./.env_other").ToArray();
             Assert.Equal(35, kvps.Length);
-            var dict = kvps.ToDictionary();
+            var dict = kvps.ToDictionary(CreateDictionaryOption.TakeLast);
 
             // note that env vars get only the final assignment, but all are returned
             Assert.Equal("dupe2", Environment.GetEnvironmentVariable("DUPLICATE"));

--- a/test/DotNetEnv.Tests/EnvTests.cs
+++ b/test/DotNetEnv.Tests/EnvTests.cs
@@ -284,7 +284,7 @@ base64
 
             var kvps = DotNetEnv.Env.Load("./.env_other").ToArray();
             Assert.Equal(35, kvps.Length);
-            var dict = kvps.ToDictionary(CreateDictionaryOption.TakeLast);
+            var dict = kvps.ToDotEnvDictionary();
 
             // note that env vars get only the final assignment, but all are returned
             Assert.Equal("dupe2", Environment.GetEnvironmentVariable("DUPLICATE"));

--- a/test/DotNetEnv.Tests/ExtensionsTests.cs
+++ b/test/DotNetEnv.Tests/ExtensionsTests.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using DotNetEnv.Extensions;
+using Xunit;
+
+namespace DotNetEnv.Tests;
+
+public class ExtensionsTests
+{
+    [Fact]
+    public void ToDotEnvDictionaryTest()
+    {
+        var kvpSetNoDupe = new List<KeyValuePair<string, string>>()
+        {
+            new("key", "value"),
+            new("key2", "value2"),
+        };
+
+        var kvpSetWithDupe = new List<KeyValuePair<string, string>>()
+        {
+            new("key", "value"),
+            new("key", "value2"),
+        };
+
+        Assert.Throws<ArgumentException>(() => kvpSetWithDupe.ToDotEnvDictionary(CreateDictionaryOption.Throw));
+        var noDupeAndThrowOption = kvpSetNoDupe.ToDotEnvDictionary(CreateDictionaryOption.Throw);
+        Assert.Equal("value", noDupeAndThrowOption["key"]);
+        Assert.Equal("value2", noDupeAndThrowOption["key2"]);
+
+        var withDupeAndTakeFirstOption = kvpSetWithDupe.ToDotEnvDictionary(CreateDictionaryOption.TakeFirst);
+        Assert.Equal("value", withDupeAndTakeFirstOption["key"]);
+        var noDupeAndTakeFirstOption = kvpSetNoDupe.ToDotEnvDictionary(CreateDictionaryOption.TakeFirst);
+        Assert.Equal("value", noDupeAndTakeFirstOption["key"]);
+        Assert.Equal("value2", noDupeAndTakeFirstOption["key2"]);
+
+        var withDupeAndTakeLastOption = kvpSetWithDupe.ToDotEnvDictionary();
+        Assert.Equal("value2", withDupeAndTakeLastOption["key"]);
+        var noDupeAndTakeLastOption = kvpSetNoDupe.ToDotEnvDictionary();
+        Assert.Equal("value", noDupeAndTakeLastOption["key"]);
+        Assert.Equal("value2", noDupeAndTakeLastOption["key2"]);
+    }
+}

--- a/test/DotNetEnv.Tests/LoadOptionsTests.cs
+++ b/test/DotNetEnv.Tests/LoadOptionsTests.cs
@@ -1,4 +1,3 @@
-using System;
 using Xunit;
 
 namespace DotNetEnv.Tests

--- a/test/DotNetEnv.Tests/ParserTests.cs
+++ b/test/DotNetEnv.Tests/ParserTests.cs
@@ -58,6 +58,7 @@ namespace DotNetEnv.Tests
             Assert.Throws<ParseException>(() => Parsers.Identifier.End().Parse("a!b"));
             Assert.Throws<ParseException>(() => Parsers.Identifier.End().Parse("a?b"));
             Assert.Throws<ParseException>(() => Parsers.Identifier.End().Parse("a*b"));
+            Assert.Throws<ParseException>(() => Parsers.Identifier.End().Parse("a:b"));
         }
 
         [Fact]

--- a/test/DotNetEnv.Tests/ParserTests.cs
+++ b/test/DotNetEnv.Tests/ParserTests.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Text;
 using Xunit;
 using Sprache;
-using DotNetEnv;
 
 namespace DotNetEnv.Tests
 {

--- a/test/DotNetEnvTraverse.Tests/TraverseTests.cs
+++ b/test/DotNetEnvTraverse.Tests/TraverseTests.cs
@@ -1,7 +1,8 @@
 using System;
 using System.Linq;
 using Xunit;
-using DotNetEnv;  // only needed for ToDictionary extension method
+using DotNetEnv;
+using DotNetEnv.Extensions; // only needed for ToDictionary extension method
 
 namespace DotNetEnvTraverse.Tests
 {
@@ -18,7 +19,7 @@ namespace DotNetEnvTraverse.Tests
         {
             var kvps = DotNetEnv.Env.TraversePath().Load().ToArray();
             Assert.Single(kvps);
-            var dict = kvps.ToDictionary();
+            var dict = kvps.ToDictionary(CreateDictionaryOption.TakeLast);
             Assert.Equal("here", dict["TEST"]);
             Assert.Equal("here", Environment.GetEnvironmentVariable("TEST"));
             Assert.Null(Environment.GetEnvironmentVariable("NAME"));
@@ -29,7 +30,7 @@ namespace DotNetEnvTraverse.Tests
         {
             var kvps = DotNetEnv.Env.TraversePath().Load("./.env").ToArray();
             Assert.Single(kvps);
-            var dict = kvps.ToDictionary();
+            var dict = kvps.ToDictionary(CreateDictionaryOption.TakeLast);
             Assert.Equal("here", dict["TEST"]);
             Assert.Equal("here", Environment.GetEnvironmentVariable("TEST"));
             Assert.Null(Environment.GetEnvironmentVariable("NAME"));
@@ -40,7 +41,7 @@ namespace DotNetEnvTraverse.Tests
         {
             var kvps = DotNetEnv.Env.TraversePath().Load(".env_much_higher").ToArray();
             Assert.Single(kvps);
-            var dict = kvps.ToDictionary();
+            var dict = kvps.ToDictionary(CreateDictionaryOption.TakeLast);
             Assert.Equal("See DotNetEnvTraverse.Tests for why this is here", dict["TEST"]);
             Assert.Equal("See DotNetEnvTraverse.Tests for why this is here", Environment.GetEnvironmentVariable("TEST"));
             Assert.Null(Environment.GetEnvironmentVariable("NAME"));
@@ -51,7 +52,7 @@ namespace DotNetEnvTraverse.Tests
         {
             var kvps = DotNetEnv.Env.TraversePath().Load("./").ToArray();
             Assert.Single(kvps);
-            var dict = kvps.ToDictionary();
+            var dict = kvps.ToDictionary(CreateDictionaryOption.TakeLast);
             Assert.Equal("here", dict["TEST"]);
             Assert.Equal("here", Environment.GetEnvironmentVariable("TEST"));
             Assert.Null(Environment.GetEnvironmentVariable("NAME"));

--- a/test/DotNetEnvTraverse.Tests/TraverseTests.cs
+++ b/test/DotNetEnvTraverse.Tests/TraverseTests.cs
@@ -1,8 +1,7 @@
 using System;
 using System.Linq;
 using Xunit;
-using DotNetEnv;
-using DotNetEnv.Extensions; // only needed for ToDictionary extension method
+using DotNetEnv.Extensions;
 
 namespace DotNetEnvTraverse.Tests
 {

--- a/test/DotNetEnvTraverse.Tests/TraverseTests.cs
+++ b/test/DotNetEnvTraverse.Tests/TraverseTests.cs
@@ -19,7 +19,7 @@ namespace DotNetEnvTraverse.Tests
         {
             var kvps = DotNetEnv.Env.TraversePath().Load().ToArray();
             Assert.Single(kvps);
-            var dict = kvps.ToDictionary(CreateDictionaryOption.TakeLast);
+            var dict = kvps.ToDotEnvDictionary();
             Assert.Equal("here", dict["TEST"]);
             Assert.Equal("here", Environment.GetEnvironmentVariable("TEST"));
             Assert.Null(Environment.GetEnvironmentVariable("NAME"));
@@ -30,7 +30,7 @@ namespace DotNetEnvTraverse.Tests
         {
             var kvps = DotNetEnv.Env.TraversePath().Load("./.env").ToArray();
             Assert.Single(kvps);
-            var dict = kvps.ToDictionary(CreateDictionaryOption.TakeLast);
+            var dict = kvps.ToDotEnvDictionary();
             Assert.Equal("here", dict["TEST"]);
             Assert.Equal("here", Environment.GetEnvironmentVariable("TEST"));
             Assert.Null(Environment.GetEnvironmentVariable("NAME"));
@@ -41,7 +41,7 @@ namespace DotNetEnvTraverse.Tests
         {
             var kvps = DotNetEnv.Env.TraversePath().Load(".env_much_higher").ToArray();
             Assert.Single(kvps);
-            var dict = kvps.ToDictionary(CreateDictionaryOption.TakeLast);
+            var dict = kvps.ToDotEnvDictionary();
             Assert.Equal("See DotNetEnvTraverse.Tests for why this is here", dict["TEST"]);
             Assert.Equal("See DotNetEnvTraverse.Tests for why this is here", Environment.GetEnvironmentVariable("TEST"));
             Assert.Null(Environment.GetEnvironmentVariable("NAME"));
@@ -52,7 +52,7 @@ namespace DotNetEnvTraverse.Tests
         {
             var kvps = DotNetEnv.Env.TraversePath().Load("./").ToArray();
             Assert.Single(kvps);
-            var dict = kvps.ToDictionary(CreateDictionaryOption.TakeLast);
+            var dict = kvps.ToDotEnvDictionary();
             Assert.Equal("here", dict["TEST"]);
             Assert.Equal("here", Environment.GetEnvironmentVariable("TEST"));
             Assert.Null(Environment.GetEnvironmentVariable("NAME"));


### PR DESCRIPTION
!BREAKING CHANGE!
Refactor KeyValuePair-Linq-Extension to use a CreateDictionaryOption.
Breaks running code, because dupes will throw now by default, but makes the behavior of ToDictionary() on KeyValuePair to return the expected results.

You easily take that extension outside of the DotEnv-scope by fault, where you would expect it to throw on dupes rather than taking the last occurrence. Especially since all IDEs heavily encourage you to add usings more or less automagically, and due to the high expectations about Linq-Extensions handling so much List-Work, you just don't recognize that this ToDictionary method will not do what you really expect.

That is one of the main reasons why I do not use this library at the moment, but I would really like to see this repo evolving a little bit further and then using it too.