### PR TITLE
fix "NoClobber" option in combination with EnvConfigurationProvider

### DIFF
--- a/src/DotNetEnv/Configuration/EnvConfigurationProvider.cs
+++ b/src/DotNetEnv/Configuration/EnvConfigurationProvider.cs
@@ -44,7 +44,8 @@ namespace DotNetEnv.Configuration
 
             if (!options.ClobberExistingVars)
                 foreach (string key in Environment.GetEnvironmentVariables().Keys)
-                    dotEnvDictionary.Remove(key);
+                    if (dotEnvDictionary.ContainsKey(key))
+                        dotEnvDictionary[key] = Environment.GetEnvironmentVariable(key);
 
             foreach (var value in dotEnvDictionary)
                 Data[NormalizeKey(value.Key)] = value.Value;

--- a/src/DotNetEnv/Configuration/EnvConfigurationProvider.cs
+++ b/src/DotNetEnv/Configuration/EnvConfigurationProvider.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using DotNetEnv.Extensions;
 using Microsoft.Extensions.Configuration;
 
@@ -37,9 +38,15 @@ namespace DotNetEnv.Configuration
                 }
             }
 
-            // Since the Load method does not take care of cloberring, We have to check it here!
+            // Since the Load method does not take care of clobberring, We have to check it here!
             var dictionaryOption = options.ClobberExistingVars ? CreateDictionaryOption.TakeLast : CreateDictionaryOption.TakeFirst;
-            foreach (var value in values.ToDotEnvDictionary(dictionaryOption))
+            var dotEnvDictionary = values.ToDotEnvDictionary(dictionaryOption);
+
+            if (!options.ClobberExistingVars)
+                foreach (string key in Environment.GetEnvironmentVariables().Keys)
+                    dotEnvDictionary.Remove(key);
+
+            foreach (var value in dotEnvDictionary)
                 Data[NormalizeKey(value.Key)] = value.Value;
         }
 

--- a/test/DotNetEnv.Tests/.env
+++ b/test/DotNetEnv.Tests/.env
@@ -7,3 +7,4 @@ CONNECTION=user=test;password=secret
   WHITEBOTH='  leading and trailing white space   '
 PASSWORD=Google#Facebook
 SSL_CERT="SPECIAL STUFF---\nLONG-BASE64\ignore\"slash"
+ENVVAR_TEST=overridden

--- a/test/DotNetEnv.Tests/.env2
+++ b/test/DotNetEnv.Tests/.env2
@@ -7,3 +7,4 @@ EMBEDEXPORT="some text export other text"
 WHITELEAD='  leading white space followed by comment'  # comment
 UNICODE="\u00ae \U0001F680 日本"
 NAME=Other
+ENVVAR_TEST=overridden_2

--- a/test/DotNetEnv.Tests/DotNetEnv.Tests.csproj
+++ b/test/DotNetEnv.Tests/DotNetEnv.Tests.csproj
@@ -42,6 +42,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="1.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Sprache" Version="2.3.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/test/DotNetEnv.Tests/DotNetEnv.Tests.csproj
+++ b/test/DotNetEnv.Tests/DotNetEnv.Tests.csproj
@@ -42,7 +42,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="1.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Sprache" Version="2.3.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/test/DotNetEnv.Tests/EnvConfigurationTests.cs
+++ b/test/DotNetEnv.Tests/EnvConfigurationTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using DotNetEnv.Configuration;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Configuration.EnvironmentVariables;
 using Xunit;
 
 namespace DotNetEnv.Tests
@@ -93,14 +92,7 @@ namespace DotNetEnv.Tests
                 .Build();
 
             Assert.Equal("Toni", this.configuration["NAME"]);
-            Assert.Null(configuration["ENVVAR_TEST"]); // the configuration should not clobber the existing EnvironmentVariable ==> no entry in this configuration
-
-            var configurationIncludingEnvironmentVars = new ConfigurationBuilder()
-                .Add(new EnvironmentVariablesConfigurationSource())
-                .AddDotNetEnvMulti(new[] { "./.env", "./.env2" }, LoadOptions.NoEnvVars().NoClobber())
-                .Build();
-
-            Assert.Equal("ENV value", configurationIncludingEnvironmentVars["ENVVAR_TEST"]); // the configuration should not clobber the existing EnvironmentVariable ==> we receive the EnvironmentVariable-Value directly from EnvironmentVariables
+            Assert.Equal("ENV value", configuration["ENVVAR_TEST"]);
         }
 
         [Fact]


### PR DESCRIPTION
**Problem Description**

I'm not 100% sure about this one, because I'm not sure where and in which way `NoClobber` should be effective.
My understading is as follows:

If we set the NoClobber option, we want the configuration to return the initial Environment-Variable if present.
And if the key is duplicated within the EnvFiles, we want to have the first occurrence (this is already working).

This is all working fine if we use the option `SetEnvVars` and let the configuration rely on the default `EnvironmentVariablesConfigurationSource` only.
This way we do not use the new `EnvConfigurationSource` at all.
One really poor thing about this: when reading the EnvFile takes place after building the Configuration, the updated EnvVars will not be used, because they do not reload by default in the `EnvironmentVariablesConfigurationProvider`. So you are forced to read EnvFile first, or reload the `ConfigurationManager` manually after reading the EnvFiles/updating the EnvironmentVariables.

With the `EnvConfigurationConfigurationSource` in place we get rid of the reload problem, because we do not care about the `EnvironmentVariablesConfigurationSource` (except if someone adds the `EnvConfigurationSource` before the default `EnvironmentVariablesConfigurationSource`, which should be a rare scenario I guess).
But we add the problem, that we now "hide/clobber" EnvironmentVariables while the option "NoClobber" is set.

**Solution**

I see three possible solutions to this problem (all 3 only for NoClobber is set of course):
1. insert EnvConfigurationSource before default EnvironmentVariablesConfigurationSource
2. remove corresponding entries from EnvConfiguration-collection
3. **update values in the EnvConfiguration-collection with the actual EnvironmentVariable-Value**

The current PR solves the problem with the 3rd option, which brings the most "independence" from other circumstances I think.

**Additional Info about the solutions**

First I solved it via option 2, which leads to some unexpected (while "correct") cases, where you miss specific values if you rely on EnvConfigurationSource only. (have a look at the first commit if interested, the problematic but correct behavior is shown in a test-case)

Solution 1 and 2 both rely directly on the order of providers to implement the "NoClobber"-option correctly.
Solution 3 in contrast to this solves the NoClobber problem by "embedding" the resulting values directly in the provided values, which removes the direct dependency to the order of providers.
Of course there is still a dependency to the order of providers, but that is the "default" order dependency, and by having the new provider after the default ones (the default case), we get the correct results. If someone changes this order on purpose (and it is near to impossible to change that order by fault) he is self-responsible for the correct order.