### PR TITLE
Add option to disable Interpolation

### DIFF
--- a/src/DotNetEnv/Env.cs
+++ b/src/DotNetEnv/Env.cs
@@ -71,16 +71,16 @@ namespace DotNetEnv
             {
                 if (options.ClobberExistingVars)
                 {
-                    return Parsers.ParseDotenvFile(contents, Parsers.SetEnvVar);
+                    return Parsers.ParseDotenvFile(contents, Parsers.SetEnvVar, options.InterpolationEnabled);
                 }
                 else
                 {
-                    return Parsers.ParseDotenvFile(contents, Parsers.NoClobberSetEnvVar);
+                    return Parsers.ParseDotenvFile(contents, Parsers.NoClobberSetEnvVar, options.InterpolationEnabled);
                 }
             }
             else
             {
-                return Parsers.ParseDotenvFile(contents, Parsers.DoNotSetEnvVar);
+                return Parsers.ParseDotenvFile(contents, Parsers.DoNotSetEnvVar, options.InterpolationEnabled);
             }
         }
 
@@ -99,5 +99,6 @@ namespace DotNetEnv
         public static LoadOptions NoEnvVars () => LoadOptions.NoEnvVars();
         public static LoadOptions NoClobber () => LoadOptions.NoClobber();
         public static LoadOptions TraversePath () => LoadOptions.TraversePath();
+        public static LoadOptions DisableInterpolation () => LoadOptions.DisableInterpolation();
     }
 }

--- a/src/DotNetEnv/IValue.cs
+++ b/src/DotNetEnv/IValue.cs
@@ -52,13 +52,15 @@ namespace DotNetEnv
         public string Value { get; private set; }
         public string RawValue { get; private set; }
 
-        public ValueCalculator (IList<IValue> values)
+        public ValueCalculator (IEnumerable<IValue> values)
         {
-            RawValue = string.Concat(values.Select(val => val.GetValue(false)));
+            var enumeratedValues = values as IValue[] ?? values.ToArray();
+
+            RawValue = string.Concat(enumeratedValues.Select(val => val.GetValue(false)));
             
             // note that we do want this lookup / calculation / GetValue calls in the ctor
             // because it is the state of the world at the moment that this value is calculated
-            Value = string.Join(string.Empty, values.Select(val => val.GetValue(true)));
+            Value = string.Concat(enumeratedValues.Select(val => val.GetValue(true)));
         }
     }
 }

--- a/src/DotNetEnv/LoadOptions.cs
+++ b/src/DotNetEnv/LoadOptions.cs
@@ -9,26 +9,31 @@ namespace DotNetEnv
         public bool SetEnvVars { get; }
         public bool ClobberExistingVars { get; }
         public bool OnlyExactPath { get; }
+        public bool InterpolationEnabled { get; }
 
         public LoadOptions(
             bool setEnvVars = true,
             bool clobberExistingVars = true,
-            bool onlyExactPath = true
+            bool onlyExactPath = true,
+            bool enableInterpolation = true
         ) {
             SetEnvVars = setEnvVars;
             ClobberExistingVars = clobberExistingVars;
             OnlyExactPath = onlyExactPath;
+            InterpolationEnabled = enableInterpolation;
         }
 
         public LoadOptions(
             LoadOptions old,
             bool? setEnvVars = null,
             bool? clobberExistingVars = null,
-            bool? onlyExactPath = null
+            bool? onlyExactPath = null,
+            bool? enableInterpolation = null
         ) {
             SetEnvVars = setEnvVars ?? old.SetEnvVars;
             ClobberExistingVars = clobberExistingVars ?? old.ClobberExistingVars;
             OnlyExactPath = onlyExactPath ?? old.OnlyExactPath;
+            InterpolationEnabled = enableInterpolation ?? old.InterpolationEnabled;
         }
 
         public static LoadOptions NoEnvVars (LoadOptions options = null) =>
@@ -40,9 +45,13 @@ namespace DotNetEnv
         public static LoadOptions TraversePath (LoadOptions options = null) =>
             options == null ? DEFAULT.TraversePath() : options.TraversePath();
 
+        public static LoadOptions DisableInterpolation (LoadOptions options = null) =>
+            options == null ? DEFAULT.DisableInterpolation() : options.DisableInterpolation();
+
         public LoadOptions NoEnvVars () => new LoadOptions(this, setEnvVars: false);
         public LoadOptions NoClobber () => new LoadOptions(this, clobberExistingVars: false);
         public LoadOptions TraversePath () => new LoadOptions(this, onlyExactPath: false);
+        public LoadOptions DisableInterpolation () => new LoadOptions(this, enableInterpolation: false);
 
         public IEnumerable<KeyValuePair<string, string>> Load (string path = null) => Env.Load(path, this);
         public IEnumerable<KeyValuePair<string, string>> LoadMulti (string[] paths) => Env.LoadMulti(paths, this);

--- a/src/DotNetEnv/Parsers.cs
+++ b/src/DotNetEnv/Parsers.cs
@@ -187,7 +187,7 @@ namespace DotNetEnv
                     from partOfValue in NotControlNorWhitespace("$\"'") // quotes are not allowed in values, because in a shell they mean something different
                     select new ValueActual(string.Concat(inlineWhitespaces, partOfValue)))
                 .Many()
-                .Select(vs => new ValueCalculator(vs.ToArray()));
+                .Select(vs => new ValueCalculator(vs));
 
         internal static readonly Parser<ValueCalculator> UnquotedValue =
             from _ in Parse.Chars(" \t\"'").Not()
@@ -203,7 +203,7 @@ namespace DotNetEnv
                 .Or(Parse.WhiteSpace.AtLeastOnce().Text())
                 .AtLeastOnce()
                 .Select(strs => new ValueActual(strs))
-            ).Many().Select(vs => new ValueCalculator(vs.ToArray()));
+            ).Many().Select(vs => new ValueCalculator(vs));
 
         // single quoted values can have whitespace,
         // but no interpolation, no escaped chars, no byte code chars
@@ -215,7 +215,7 @@ namespace DotNetEnv
                 .AtLeastOnce()
                 .Select(strs => new ValueActual(strs))
                 .Many()
-                .Select(vs => new ValueCalculator(vs.ToArray<IValue>()));
+                .Select(vs => new ValueCalculator(vs));
 
         // compare against bash quoting rules:
         // https://stackoverflow.com/questions/6697753/difference-between-single-and-double-quotes-in-bash/42082956#42082956

--- a/test/DotNetEnv.Tests/EnvTests.cs
+++ b/test/DotNetEnv.Tests/EnvTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Linq;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -8,9 +9,24 @@ using Sprache;
 
 namespace DotNetEnv.Tests
 {
-    public class EnvTests
+    public class EnvTests : IDisposable
     {
+        private readonly IDictionary _environmentVariablesSnapshot;
         private static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+        public EnvTests()
+        {
+            _environmentVariablesSnapshot = Environment.GetEnvironmentVariables();
+        }
+
+        public void Dispose()
+        {
+            foreach (DictionaryEntry dictionaryEntry in Environment.GetEnvironmentVariables())
+                Environment.SetEnvironmentVariable(dictionaryEntry.Key.ToString()!,
+                    _environmentVariablesSnapshot.Contains(dictionaryEntry.Key)
+                        ? _environmentVariablesSnapshot[dictionaryEntry.Key]!.ToString()
+                        : null);
+        }
 
         [Fact]
         public void LoadTest()

--- a/test/DotNetEnv.Tests/LoadOptionsTests.cs
+++ b/test/DotNetEnv.Tests/LoadOptionsTests.cs
@@ -13,16 +13,25 @@ namespace DotNetEnv.Tests
             Assert.False(options.SetEnvVars);
             Assert.True(options.ClobberExistingVars);
             Assert.True(options.OnlyExactPath);
+            Assert.True(options.InterpolationEnabled);
 
             options = DotNetEnv.Env.NoClobber();
             Assert.True(options.SetEnvVars);
             Assert.False(options.ClobberExistingVars);
             Assert.True(options.OnlyExactPath);
+            Assert.True(options.InterpolationEnabled);
 
             options = DotNetEnv.Env.TraversePath();
             Assert.True(options.SetEnvVars);
             Assert.True(options.ClobberExistingVars);
             Assert.False(options.OnlyExactPath);
+            Assert.True(options.InterpolationEnabled);
+
+            options = DotNetEnv.Env.DisableInterpolation();
+            Assert.True(options.SetEnvVars);
+            Assert.True(options.ClobberExistingVars);
+            Assert.True(options.OnlyExactPath);
+            Assert.False(options.InterpolationEnabled);
         }
 
         [Fact]
@@ -34,16 +43,25 @@ namespace DotNetEnv.Tests
             Assert.False(options.SetEnvVars);
             Assert.True(options.ClobberExistingVars);
             Assert.True(options.OnlyExactPath);
+            Assert.True(options.InterpolationEnabled);
 
             options = DotNetEnv.LoadOptions.NoClobber();
             Assert.True(options.SetEnvVars);
             Assert.False(options.ClobberExistingVars);
             Assert.True(options.OnlyExactPath);
+            Assert.True(options.InterpolationEnabled);
 
             options = DotNetEnv.LoadOptions.TraversePath();
             Assert.True(options.SetEnvVars);
             Assert.True(options.ClobberExistingVars);
             Assert.False(options.OnlyExactPath);
+            Assert.True(options.InterpolationEnabled);
+
+            options = DotNetEnv.LoadOptions.DisableInterpolation();
+            Assert.True(options.SetEnvVars);
+            Assert.True(options.ClobberExistingVars);
+            Assert.True(options.OnlyExactPath);
+            Assert.False(options.InterpolationEnabled);
         }
 
         [Fact]
@@ -55,21 +73,31 @@ namespace DotNetEnv.Tests
             Assert.True(options.SetEnvVars);
             Assert.True(options.ClobberExistingVars);
             Assert.True(options.OnlyExactPath);
+            Assert.True(options.InterpolationEnabled);
 
             options = new DotNetEnv.LoadOptions().NoEnvVars();
             Assert.False(options.SetEnvVars);
             Assert.True(options.ClobberExistingVars);
             Assert.True(options.OnlyExactPath);
+            Assert.True(options.InterpolationEnabled);
 
             options = new DotNetEnv.LoadOptions().NoClobber();
             Assert.True(options.SetEnvVars);
             Assert.False(options.ClobberExistingVars);
             Assert.True(options.OnlyExactPath);
+            Assert.True(options.InterpolationEnabled);
 
             options = new DotNetEnv.LoadOptions().TraversePath();
             Assert.True(options.SetEnvVars);
             Assert.True(options.ClobberExistingVars);
             Assert.False(options.OnlyExactPath);
+            Assert.True(options.InterpolationEnabled);
+
+            options = new DotNetEnv.LoadOptions().DisableInterpolation();
+            Assert.True(options.SetEnvVars);
+            Assert.True(options.ClobberExistingVars);
+            Assert.True(options.OnlyExactPath);
+            Assert.False(options.InterpolationEnabled);
         }
 
         [Fact]
@@ -77,25 +105,35 @@ namespace DotNetEnv.Tests
         {
             LoadOptions options;
 
+            options = DotNetEnv.Env.NoEnvVars().NoClobber().TraversePath().DisableInterpolation();
+            Assert.False(options.SetEnvVars);
+            Assert.False(options.ClobberExistingVars);
+            Assert.False(options.OnlyExactPath);
+            Assert.False(options.InterpolationEnabled);
+
             options = DotNetEnv.Env.NoEnvVars().NoClobber().TraversePath();
             Assert.False(options.SetEnvVars);
             Assert.False(options.ClobberExistingVars);
             Assert.False(options.OnlyExactPath);
+            Assert.True(options.InterpolationEnabled);
 
             options = DotNetEnv.Env.NoClobber().TraversePath();
             Assert.True(options.SetEnvVars);
             Assert.False(options.ClobberExistingVars);
             Assert.False(options.OnlyExactPath);
+            Assert.True(options.InterpolationEnabled);
 
             options = DotNetEnv.Env.NoEnvVars().NoClobber();
             Assert.False(options.SetEnvVars);
             Assert.False(options.ClobberExistingVars);
             Assert.True(options.OnlyExactPath);
+            Assert.True(options.InterpolationEnabled);
 
             options = DotNetEnv.Env.NoEnvVars().TraversePath();
             Assert.False(options.SetEnvVars);
             Assert.True(options.ClobberExistingVars);
             Assert.False(options.OnlyExactPath);
+            Assert.True(options.InterpolationEnabled);
         }
     }
 }

--- a/test/DotNetEnv.Tests/ParserTests.cs
+++ b/test/DotNetEnv.Tests/ParserTests.cs
@@ -360,7 +360,7 @@ namespace DotNetEnv.Tests
         {
             Action<string, string, string> testParse = (key, value, input) =>
             {
-                var kvp = Parsers.Assignment.End().Parse(input);
+                var kvp = Parsers.Assignment().End().Parse(input);
                 Assert.Equal(key, kvp.Key);
                 Assert.Equal(value, kvp.Value);
             };
@@ -375,7 +375,7 @@ namespace DotNetEnv.Tests
             testParse("EV_DNE", @"\xe6\x97\xa5 \xe6\x9c\xac", @"EV_DNE=\xe6\x97\xa5 \xe6\x9c\xac");
             testParse("EV_DNE", @"\xE2\x98\xA0 \uae", @"EV_DNE=\xE2\x98\xA0 \uae");
 
-            var kvp = Parsers.Assignment.End().Parse("EV_DNE=");
+            var kvp = Parsers.Assignment().End().Parse("EV_DNE=");
             Assert.Equal("EV_DNE", kvp.Key);
             Assert.Equal("", kvp.Value);
             // Note that dotnet returns null if the env var is empty -- even if it was set to empty!
@@ -384,8 +384,8 @@ namespace DotNetEnv.Tests
             // TODO: is it possible to get the system to recognize when a complete unicode char is present and start the next one then, without a space?
 //            Assert.Equal("EV_DNE=日本", Parsers.Assignment.End().Parse(@"EV_DNE=\xe6\x97\xa5\xe6\x9c\xac"));
 
-            Assert.Throws<ParseException>(() => Parsers.Assignment.End().Parse("EV_DNE='"));
-            Assert.Throws<ParseException>(() => Parsers.Assignment.End().Parse("EV_DNE=0\n1"));
+            Assert.Throws<ParseException>(() => Parsers.Assignment().End().Parse("EV_DNE='"));
+            Assert.Throws<ParseException>(() => Parsers.Assignment().End().Parse("EV_DNE=0\n1"));
 
             testParse("EV_DNE", "", "EV_DNE=");
             testParse("EV_DNE", "EV_DNE=", "EV_DNE=EV_DNE=");
@@ -425,14 +425,14 @@ namespace DotNetEnv.Tests
             testParse("EV_DNE", "a'b'' 'c' d", "EV_DNE=\"a'b'' 'c' d\" #allow singleQuotes in doubleQuoted values");
             testParse("EV_DNE", "a\"b\"\" \"c\" d", "EV_DNE='a\"b\"\" \"c\" d' #allow doubleQuotes in singleQuoted values");
             testParse("EV_DNE", "a\"b\"\" \"c\" d", "EV_DNE=\"a\\\"b\\\"\\\" \\\"c\\\" d\" #allow escaped doubleQuotes in doubleQuoted values");
-            Assert.Throws<ParseException>(() => Parsers.Assignment.Parse("EV_DNE='a'b'' 'c' d'"));  // no singleQuotes inside singleQuoted values
-            Assert.Throws<ParseException>(() => Parsers.Assignment.Parse("EV_DNE=\"a\"b\""));  // no unescaped doubleQuotes inside doubleQuoted values
+            Assert.Throws<ParseException>(() => Parsers.Assignment().Parse("EV_DNE='a'b'' 'c' d'"));  // no singleQuotes inside singleQuoted values
+            Assert.Throws<ParseException>(() => Parsers.Assignment().Parse("EV_DNE=\"a\"b\""));  // no unescaped doubleQuotes inside doubleQuoted values
 
             testParse("EV_DNE", "VAL UE", "EV_DNE=VAL UE");
             testParse("EV_DNE", "VAL UE", "EV_DNE=VAL UE #comment");
 
-            Assert.Throws<ParseException>(() => Parsers.Assignment.End().Parse("EV_DNE='a b c'EV_TEST_1=more"));
-            Assert.Throws<ParseException>(() => Parsers.Assignment.End().Parse("EV_DNE='a b c' EV_TEST_1=more"));
+            Assert.Throws<ParseException>(() => Parsers.Assignment().End().Parse("EV_DNE='a b c'EV_TEST_1=more"));
+            Assert.Throws<ParseException>(() => Parsers.Assignment().End().Parse("EV_DNE='a b c' EV_TEST_1=more"));
         }
 
         [Fact]


### PR DESCRIPTION
I've added an option to disable the Interpolation.
Main reasons:
- the current Interpolation-Implementation stops working if you do not set EnvironmentVariables (see #92) ==> it is good to have the option to disable it completely
- Interpolation adds complexity which is not needed in every setup ==> good to have the option to reduce complexity

It was way harder to achieve than expected, because the Interpolation is so deep inside the static Parsers.
Changing Assignment to be a method instead of a readonly field seems to be the least intrusive way.
There is also this test in EnvTests-->ParseInterpolationDisabledTest line 224. I think this is not the really desired result, but I do not see a way how to solve that.