### PR TITLE
Added test for ParseInterpolatedNoEnvVarsTest

### DIFF
--- a/src/DotNetEnv/Env.cs
+++ b/src/DotNetEnv/Env.cs
@@ -80,8 +80,14 @@ namespace DotNetEnv
             }
             else
             {
-                return Parsers.ParseDotenvFile(contents, Parsers.DoNotSetEnvVar);
-            }
+				IEnumerable<KeyValuePair<string, string>> enumerable = Parsers.ParseDotenvFile(contents, Parsers.SetEnvVar);
+
+                enumerable
+                    .ToList()
+                    .ForEach((e) => Environment.SetEnvironmentVariable(e.Key, string.Empty));
+
+				return enumerable;
+			}
         }
 
         public static string GetString (string key, string fallback = default(string)) =>

--- a/src/DotNetEnv/Env.cs
+++ b/src/DotNetEnv/Env.cs
@@ -81,26 +81,26 @@ namespace DotNetEnv
             }
             else
             {
-				IDictionary<string, string> existingEnvironmentVariables = Environment
+                IDictionary<string, string> existingEnvironmentVariables = Environment
                     .GetEnvironmentVariables()
                     .Cast<DictionaryEntry>()
-			        .ToDictionary(entry => (string)entry.Key, entry => (string)entry.Value);
+                    .ToDictionary(entry => (string)entry.Key, entry => (string)entry.Value);
 
-				IEnumerable<KeyValuePair<string, string>> parsedEnvironmentVariables = Parsers.ParseDotenvFile(contents, Parsers.SetEnvVar);
+                IEnumerable<KeyValuePair<string, string>> parsedEnvironmentVariables = Parsers.ParseDotenvFile(contents, Parsers.SetEnvVar);
 
-				Environment
-					.GetEnvironmentVariables()
-					.Cast<DictionaryEntry>()
-					.ToDictionary(entry => (string)entry.Key, entry => (string)entry.Value)
-					.ToList()
+                Environment
+                    .GetEnvironmentVariables()
+                    .Cast<DictionaryEntry>()
+                    .ToDictionary(entry => (string)entry.Key, entry => (string)entry.Value)
+                    .ToList()
                     .ForEach((e) => Environment.SetEnvironmentVariable(e.Key, string.Empty));
 
                 existingEnvironmentVariables
                     .ToList()
                     .ForEach((e) => Environment.SetEnvironmentVariable(e.Key, e.Value));
 
-				return parsedEnvironmentVariables;
-			}
+                return parsedEnvironmentVariables;
+            }
         }
 
         public static string GetString (string key, string fallback = default(string)) =>
@@ -118,5 +118,5 @@ namespace DotNetEnv
         public static LoadOptions NoEnvVars () => LoadOptions.NoEnvVars();
         public static LoadOptions NoClobber () => LoadOptions.NoClobber();
         public static LoadOptions TraversePath () => LoadOptions.TraversePath();
-	}
+    }
 }

--- a/src/DotNetEnv/Parsers.cs
+++ b/src/DotNetEnv/Parsers.cs
@@ -14,11 +14,6 @@ namespace DotNetEnv
             return kvp;
         }
 
-        public static KeyValuePair<string, string> DoNotSetEnvVar (KeyValuePair<string, string> kvp)
-        {
-            return kvp;
-        }
-
         public static KeyValuePair<string, string> NoClobberSetEnvVar (KeyValuePair<string, string> kvp)
         {
             if (Environment.GetEnvironmentVariable(kvp.Key) == null)
@@ -272,8 +267,13 @@ namespace DotNetEnv
             string contents,
             Func<KeyValuePair<string, string>, KeyValuePair<string, string>> tranform
         ) {
-            return Assignment.Select(tranform).Or(Empty).AtLeastOnce().End()
-                .Parse(contents).Where(kvp => kvp.Key != null);
+            return Assignment
+                .Select(tranform)
+                .Or(Empty)
+                .AtLeastOnce()
+                .End()
+                .Parse(contents)
+                .Where(kvp => kvp.Key != null);
         }
     }
 }

--- a/src/DotNetEnv/Parsers.cs
+++ b/src/DotNetEnv/Parsers.cs
@@ -14,7 +14,7 @@ namespace DotNetEnv
             return kvp;
         }
 
-        public static KeyValuePair<string, string> NoClobberSetEnvVar (KeyValuePair<string, string> kvp)
+		public static KeyValuePair<string, string> NoClobberSetEnvVar (KeyValuePair<string, string> kvp)
         {
             if (Environment.GetEnvironmentVariable(kvp.Key) == null)
             {

--- a/src/DotNetEnv/Parsers.cs
+++ b/src/DotNetEnv/Parsers.cs
@@ -14,9 +14,9 @@ namespace DotNetEnv
             return kvp;
         }
 
-		public static KeyValuePair<string, string> NoClobberSetEnvVar(KeyValuePair<string, string> kvp)
-		{
-			if (Environment.GetEnvironmentVariable(kvp.Key) == null)
+        public static KeyValuePair<string, string> NoClobberSetEnvVar(KeyValuePair<string, string> kvp)
+        {
+            if (Environment.GetEnvironmentVariable(kvp.Key) == null)
             {
                 Environment.SetEnvironmentVariable(kvp.Key, kvp.Value);
             }
@@ -267,8 +267,8 @@ namespace DotNetEnv
             string contents,
             Func<KeyValuePair<string, string>, KeyValuePair<string, string>> tranform
         ) {
-			return Assignment.Select(tranform).Or(Empty).AtLeastOnce().End()
-				.Parse(contents).Where(kvp => kvp.Key != null);
-		}
+            return Assignment.Select(tranform).Or(Empty).AtLeastOnce().End()
+                .Parse(contents).Where(kvp => kvp.Key != null);
+        }
     }
 }

--- a/src/DotNetEnv/Parsers.cs
+++ b/src/DotNetEnv/Parsers.cs
@@ -14,9 +14,9 @@ namespace DotNetEnv
             return kvp;
         }
 
-		public static KeyValuePair<string, string> NoClobberSetEnvVar (KeyValuePair<string, string> kvp)
-        {
-            if (Environment.GetEnvironmentVariable(kvp.Key) == null)
+		public static KeyValuePair<string, string> NoClobberSetEnvVar(KeyValuePair<string, string> kvp)
+		{
+			if (Environment.GetEnvironmentVariable(kvp.Key) == null)
             {
                 Environment.SetEnvironmentVariable(kvp.Key, kvp.Value);
             }
@@ -267,13 +267,8 @@ namespace DotNetEnv
             string contents,
             Func<KeyValuePair<string, string>, KeyValuePair<string, string>> tranform
         ) {
-            return Assignment
-                .Select(tranform)
-                .Or(Empty)
-                .AtLeastOnce()
-                .End()
-                .Parse(contents)
-                .Where(kvp => kvp.Key != null);
-        }
+			return Assignment.Select(tranform).Or(Empty).AtLeastOnce().End()
+				.Parse(contents).Where(kvp => kvp.Key != null);
+		}
     }
 }

--- a/test/DotNetEnv.Tests/EnvTests.cs
+++ b/test/DotNetEnv.Tests/EnvTests.cs
@@ -18,7 +18,7 @@ namespace DotNetEnv.Tests
             DotNetEnv.Env.Load();
             Assert.Equal("Toni", Environment.GetEnvironmentVariable("NAME"));
             // unfortunately .NET removes empty env vars -- there can NEVER be an empty string env var value
-            // https://msdn.microsoft.com/en-us/library/z46c489x(v=vs.110).aspx#Remarks
+            //  https://msdn.microsoft.com/en-us/library/z46c489x(v=vs.110).aspx#Remarks
             Assert.Null(Environment.GetEnvironmentVariable("EMPTY"));
             Assert.Equal("'", Environment.GetEnvironmentVariable("QUOTE"));
             Assert.Equal("https://github.com/tonerdo", Environment.GetEnvironmentVariable("URL"));
@@ -163,56 +163,56 @@ namespace DotNetEnv.Tests
             Assert.Equal(IsWindows ? "lower" : null, Environment.GetEnvironmentVariable("CASING"));
         }
 
-        [Fact]
-        public void ParseInterpolatedTest()
-        {
-            System.Environment.SetEnvironmentVariable("EXISTING_ENVIRONMENT_VARIABLE", "value");
-            System.Environment.SetEnvironmentVariable("DNE_VAR", null);
-            DotNetEnv.Env.Load("./.env_embedded");
-            Assert.Equal("test", Environment.GetEnvironmentVariable("TEST"));
-            Assert.Equal("test1", Environment.GetEnvironmentVariable("TEST1"));
-            Assert.Equal("test", Environment.GetEnvironmentVariable("TEST2"));
-            Assert.Equal("testtest", Environment.GetEnvironmentVariable("TEST3"));
-            Assert.Equal("testtest1", Environment.GetEnvironmentVariable("TEST4"));
+		[Fact]
+		public void ParseInterpolatedTest()
+		{
+			System.Environment.SetEnvironmentVariable("EXISTING_ENVIRONMENT_VARIABLE", "value");
+			System.Environment.SetEnvironmentVariable("DNE_VAR", null);
+			DotNetEnv.Env.Load("./.env_embedded");
+			Assert.Equal("test", Environment.GetEnvironmentVariable("TEST"));
+			Assert.Equal("test1", Environment.GetEnvironmentVariable("TEST1"));
+			Assert.Equal("test", Environment.GetEnvironmentVariable("TEST2"));
+			Assert.Equal("testtest", Environment.GetEnvironmentVariable("TEST3"));
+			Assert.Equal("testtest1", Environment.GetEnvironmentVariable("TEST4"));
 
-            Assert.Equal("test:testtest1 $$ '\" ® and test1", Environment.GetEnvironmentVariable("TEST5_DOUBLE"));
-            Assert.Equal("$TEST:$TEST4 \\$\\$ \" \\uae and $TEST1", Environment.GetEnvironmentVariable("TEST5_SINGLE"));
-            Assert.Equal("test:testtest1\\uaeandtest1", Environment.GetEnvironmentVariable("TEST5_UNQUOTED"));
+			Assert.Equal("test:testtest1 $$ '\" ® and test1", Environment.GetEnvironmentVariable("TEST5_DOUBLE"));
+			Assert.Equal("$TEST:$TEST4 \\$\\$ \" \\uae and $TEST1", Environment.GetEnvironmentVariable("TEST5_SINGLE"));
+			Assert.Equal("test:testtest1\\uaeandtest1", Environment.GetEnvironmentVariable("TEST5_UNQUOTED"));
 
-            // note that interpolated values will keep whitespace! (as they should, esp if surrounding them with other values)
-            Assert.Equal(" surrounded by spaces ", Environment.GetEnvironmentVariable("TEST_UNQUOTED_WITH_INTERPOLATED_SURROUNDING_SPACES"));
+			// note that interpolated values will keep whitespace! (as they should, esp if surrounding them with other values)
+			Assert.Equal(" surrounded by spaces ", Environment.GetEnvironmentVariable("TEST_UNQUOTED_WITH_INTERPOLATED_SURROUNDING_SPACES"));
 
-            Assert.Equal("value1", System.Environment.GetEnvironmentVariable("FIRST_KEY"));
-            Assert.Equal("value2andvalue1", System.Environment.GetEnvironmentVariable("SECOND_KEY"));
-            // EXISTING_ENVIRONMENT_VARIABLE already set to "value"
-            Assert.Equal("value;andvalue3", System.Environment.GetEnvironmentVariable("THIRD_KEY"));
-            // DNE_VAR does not exist (has no value)
-            Assert.Equal(";nope", System.Environment.GetEnvironmentVariable("FOURTH_KEY"));
+			Assert.Equal("value1", System.Environment.GetEnvironmentVariable("FIRST_KEY"));
+			Assert.Equal("value2andvalue1", System.Environment.GetEnvironmentVariable("SECOND_KEY"));
+			// EXISTING_ENVIRONMENT_VARIABLE already set to "value"
+			Assert.Equal("value;andvalue3", System.Environment.GetEnvironmentVariable("THIRD_KEY"));
+			// DNE_VAR does not exist (has no value)
+			Assert.Equal(";nope", System.Environment.GetEnvironmentVariable("FOURTH_KEY"));
 
-            Assert.Equal("^((?!Everyone).)*$", Environment.GetEnvironmentVariable("GROUP_FILTER_REGEX"));
+			Assert.Equal("^((?!Everyone).)*$", Environment.GetEnvironmentVariable("GROUP_FILTER_REGEX"));
 
-            Assert.Equal("value$", Environment.GetEnvironmentVariable("DOLLAR1_U"));
-            Assert.Equal("valuevalue$$", Environment.GetEnvironmentVariable("DOLLAR2_U"));
-            Assert.Equal("value$.$", Environment.GetEnvironmentVariable("DOLLAR3_U"));
-            Assert.Equal("value$$", Environment.GetEnvironmentVariable("DOLLAR4_U"));
+			Assert.Equal("value$", Environment.GetEnvironmentVariable("DOLLAR1_U"));
+			Assert.Equal("valuevalue$$", Environment.GetEnvironmentVariable("DOLLAR2_U"));
+			Assert.Equal("value$.$", Environment.GetEnvironmentVariable("DOLLAR3_U"));
+			Assert.Equal("value$$", Environment.GetEnvironmentVariable("DOLLAR4_U"));
 
-            Assert.Equal("value$", Environment.GetEnvironmentVariable("DOLLAR1_S"));
-            Assert.Equal("value$DOLLAR1_S$", Environment.GetEnvironmentVariable("DOLLAR2_S"));
-            Assert.Equal("value$.$", Environment.GetEnvironmentVariable("DOLLAR3_S"));
-            Assert.Equal("value$$", Environment.GetEnvironmentVariable("DOLLAR4_S"));
+			Assert.Equal("value$", Environment.GetEnvironmentVariable("DOLLAR1_S"));
+			Assert.Equal("value$DOLLAR1_S$", Environment.GetEnvironmentVariable("DOLLAR2_S"));
+			Assert.Equal("value$.$", Environment.GetEnvironmentVariable("DOLLAR3_S"));
+			Assert.Equal("value$$", Environment.GetEnvironmentVariable("DOLLAR4_S"));
 
-            Assert.Equal("value$", Environment.GetEnvironmentVariable("DOLLAR1_D"));
-            Assert.Equal("valuevalue$$", Environment.GetEnvironmentVariable("DOLLAR2_D"));
-            Assert.Equal("value$.$", Environment.GetEnvironmentVariable("DOLLAR3_D"));
-            Assert.Equal("value$$", Environment.GetEnvironmentVariable("DOLLAR4_D"));
-        }
+			Assert.Equal("value$", Environment.GetEnvironmentVariable("DOLLAR1_D"));
+			Assert.Equal("valuevalue$$", Environment.GetEnvironmentVariable("DOLLAR2_D"));
+			Assert.Equal("value$.$", Environment.GetEnvironmentVariable("DOLLAR3_D"));
+			Assert.Equal("value$$", Environment.GetEnvironmentVariable("DOLLAR4_D"));
+		}
 
 		[Fact]
 		public void ParseInterpolatedNoEnvVarsTest()
 		{
-            Environment.SetEnvironmentVariable("TEST", string.Empty);
-            Environment.SetEnvironmentVariable("TEST2", string.Empty);
-            Environment.SetEnvironmentVariable("EXISTING_ENVIRONMENT_VARIABLE", "value");
+			Environment.SetEnvironmentVariable("TEST", string.Empty);
+			Environment.SetEnvironmentVariable("TEST2", string.Empty);
+			Environment.SetEnvironmentVariable("EXISTING_ENVIRONMENT_VARIABLE", "value");
 			Environment.SetEnvironmentVariable("DNE_VAR", null);
 			var environmentDictionary = DotNetEnv.Env.NoEnvVars().Load("./.env_embedded").ToDotEnvDictionary();
 			Assert.Equal("test", environmentDictionary["TEST"]);
@@ -252,39 +252,39 @@ namespace DotNetEnv.Tests
 			Assert.Equal("value$.$", environmentDictionary["DOLLAR3_D"]);
 			Assert.Equal("value$$", environmentDictionary["DOLLAR4_D"]);
 
-            // Validate that the environment is not loaded 
+			// Validate that the environment is not loaded 
 			Assert.Null(Environment.GetEnvironmentVariable("TEST"));
-            Assert.Null(Environment.GetEnvironmentVariable("TEST1"));
+			Assert.Null(Environment.GetEnvironmentVariable("TEST1"));
 			Assert.Null(Environment.GetEnvironmentVariable("TEST2"));
 			Assert.Null(Environment.GetEnvironmentVariable("TEST3"));
 			Assert.Null(Environment.GetEnvironmentVariable("TEST4"));
-                  
+
 			Assert.Null(Environment.GetEnvironmentVariable("TEST5_DOUBLE"));
 			Assert.Null(Environment.GetEnvironmentVariable("TEST5_SINGLE"));
 			Assert.Null(Environment.GetEnvironmentVariable("TEST5_UNQUOTED"));
-                  
+
 			// not.Null interpolated values will keep whitespace! (as they should, esp if surrounding them with other values)
 			Assert.Null(Environment.GetEnvironmentVariable("TEST_UNQUOTED_WITH_INTERPOLATED_SURROUNDING_SPACES"));
-                  
+
 			Assert.Null(Environment.GetEnvironmentVariable("FIRST_KEY"));
 			Assert.Null(Environment.GetEnvironmentVariable("SECOND_KEY"));
 			// EXI.NullENVIRONMENT_VARIABLE already set to "value"
 			Assert.Null(Environment.GetEnvironmentVariable("THIRD_KEY"));
 			// DNE.Nulloes not exist (has no value)
 			Assert.Null(Environment.GetEnvironmentVariable("FOURTH_KEY"));
-                  
+
 			Assert.Null(Environment.GetEnvironmentVariable("GROUP_FILTER_REGEX"));
-                  
+
 			Assert.Null(Environment.GetEnvironmentVariable("DOLLAR1_U"));
 			Assert.Null(Environment.GetEnvironmentVariable("DOLLAR2_U"));
 			Assert.Null(Environment.GetEnvironmentVariable("DOLLAR3_U"));
 			Assert.Null(Environment.GetEnvironmentVariable("DOLLAR4_U"));
-                  
+
 			Assert.Null(Environment.GetEnvironmentVariable("DOLLAR1_S"));
 			Assert.Null(Environment.GetEnvironmentVariable("DOLLAR2_S"));
 			Assert.Null(Environment.GetEnvironmentVariable("DOLLAR3_S"));
 			Assert.Null(Environment.GetEnvironmentVariable("DOLLAR4_S"));
-                  
+
 			Assert.Null(Environment.GetEnvironmentVariable("DOLLAR1_D"));
 			Assert.Null(Environment.GetEnvironmentVariable("DOLLAR2_D"));
 			Assert.Null(Environment.GetEnvironmentVariable("DOLLAR3_D"));
@@ -292,7 +292,7 @@ namespace DotNetEnv.Tests
 		}
 
 		[Fact]
-        public void QuotedHashTest()
+		public void QuotedHashTest()
         {
             DotNetEnv.Env.Load("./.env_quoted_hash");
             Assert.Equal("1234#not_comment", Environment.GetEnvironmentVariable("QTEST0"));

--- a/test/DotNetEnv.Tests/EnvTests.cs
+++ b/test/DotNetEnv.Tests/EnvTests.cs
@@ -207,52 +207,89 @@ namespace DotNetEnv.Tests
             Assert.Equal("value$$", Environment.GetEnvironmentVariable("DOLLAR4_D"));
         }
 
-        [Fact]
-        public void ParseInterpolatedNoEnvVarsTest()
-        {
-            System.Environment.SetEnvironmentVariable("EXISTING_ENVIRONMENT_VARIABLE", "value");
-            System.Environment.SetEnvironmentVariable("DNE_VAR", null);
-            var environmentDictionary = DotNetEnv.Env.NoEnvVars().Load("./.env_embedded").ToDotEnvDictionary();
-            Assert.Equal("test", environmentDictionary["TEST"]);
-            Assert.Equal("test1", environmentDictionary["TEST1"]);
-            Assert.Equal("test", environmentDictionary["TEST2"]);
-            Assert.Equal("testtest", environmentDictionary["TEST3"]);
-            Assert.Equal("testtest1", environmentDictionary["TEST4"]);
+		[Fact]
+		public void ParseInterpolatedNoEnvVarsTest()
+		{
+			Environment.SetEnvironmentVariable("EXISTING_ENVIRONMENT_VARIABLE", "value");
+			Environment.SetEnvironmentVariable("DNE_VAR", null);
+			var environmentDictionary = DotNetEnv.Env.NoEnvVars().Load("./.env_embedded").ToDotEnvDictionary();
+			Assert.Equal("test", environmentDictionary["TEST"]);
+			Assert.Equal("test1", environmentDictionary["TEST1"]);
+			Assert.Equal("test", environmentDictionary["TEST2"]);
+			Assert.Equal("testtest", environmentDictionary["TEST3"]);
+			Assert.Equal("testtest1", environmentDictionary["TEST4"]);
 
-            Assert.Equal("test:testtest1 $$ '\" ® and test1", environmentDictionary["TEST5_DOUBLE"]);
-            Assert.Equal("$TEST:$TEST4 \\$\\$ \" \\uae and $TEST1", environmentDictionary["TEST5_SINGLE"]);
-            Assert.Equal("test:testtest1\\uaeandtest1", environmentDictionary["TEST5_UNQUOTED"]);
+			Assert.Equal("test:testtest1 $$ '\" ® and test1", environmentDictionary["TEST5_DOUBLE"]);
+			Assert.Equal("$TEST:$TEST4 \\$\\$ \" \\uae and $TEST1", environmentDictionary["TEST5_SINGLE"]);
+			Assert.Equal("test:testtest1\\uaeandtest1", environmentDictionary["TEST5_UNQUOTED"]);
 
-            // note that interpolated values will keep whitespace! (as they should, esp if surrounding them with other values)
-            Assert.Equal(" surrounded by spaces ",
-                environmentDictionary["TEST_UNQUOTED_WITH_INTERPOLATED_SURROUNDING_SPACES"]);
+			// note that interpolated values will keep whitespace! (as they should, esp if surrounding them with other values)
+			Assert.Equal(" surrounded by spaces ", environmentDictionary["TEST_UNQUOTED_WITH_INTERPOLATED_SURROUNDING_SPACES"]);
 
-            Assert.Equal("value1", environmentDictionary["FIRST_KEY"]);
-            Assert.Equal("value2andvalue1", environmentDictionary["SECOND_KEY"]);
-            // EXISTING_ENVIRONMENT_VARIABLE already set to "value"
-            Assert.Equal("value;andvalue3", environmentDictionary["THIRD_KEY"]);
-            // DNE_VAR does not exist (has no value)
-            Assert.Equal(";nope", environmentDictionary["FOURTH_KEY"]);
+			Assert.Equal("value1", environmentDictionary["FIRST_KEY"]);
+			Assert.Equal("value2andvalue1", environmentDictionary["SECOND_KEY"]);
+			// EXISTING_ENVIRONMENT_VARIABLE already set to "value"
+			Assert.Equal("value;andvalue3", environmentDictionary["THIRD_KEY"]);
+			// DNE_VAR does not exist (has no value)
+			Assert.Equal(";nope", environmentDictionary["FOURTH_KEY"]);
 
-            Assert.Equal("^((?!Everyone).)*$", environmentDictionary["GROUP_FILTER_REGEX"]);
+			Assert.Equal("^((?!Everyone).)*$", environmentDictionary["GROUP_FILTER_REGEX"]);
 
-            Assert.Equal("value$", environmentDictionary["DOLLAR1_U"]);
-            Assert.Equal("valuevalue$$", environmentDictionary["DOLLAR2_U"]);
-            Assert.Equal("value$.$", environmentDictionary["DOLLAR3_U"]);
-            Assert.Equal("value$$", environmentDictionary["DOLLAR4_U"]);
+			Assert.Equal("value$", environmentDictionary["DOLLAR1_U"]);
+			Assert.Equal("valuevalue$$", environmentDictionary["DOLLAR2_U"]);
+			Assert.Equal("value$.$", environmentDictionary["DOLLAR3_U"]);
+			Assert.Equal("value$$", environmentDictionary["DOLLAR4_U"]);
 
-            Assert.Equal("value$", environmentDictionary["DOLLAR1_S"]);
-            Assert.Equal("value$DOLLAR1_S$", environmentDictionary["DOLLAR2_S"]);
-            Assert.Equal("value$.$", environmentDictionary["DOLLAR3_S"]);
-            Assert.Equal("value$$", environmentDictionary["DOLLAR4_S"]);
+			Assert.Equal("value$", environmentDictionary["DOLLAR1_S"]);
+			Assert.Equal("value$DOLLAR1_S$", environmentDictionary["DOLLAR2_S"]);
+			Assert.Equal("value$.$", environmentDictionary["DOLLAR3_S"]);
+			Assert.Equal("value$$", environmentDictionary["DOLLAR4_S"]);
 
-            Assert.Equal("value$", environmentDictionary["DOLLAR1_D"]);
-            Assert.Equal("valuevalue$$", environmentDictionary["DOLLAR2_D"]);
-            Assert.Equal("value$.$", environmentDictionary["DOLLAR3_D"]);
-            Assert.Equal("value$$", environmentDictionary["DOLLAR4_D"]);
-        }
+			Assert.Equal("value$", environmentDictionary["DOLLAR1_D"]);
+			Assert.Equal("valuevalue$$", environmentDictionary["DOLLAR2_D"]);
+			Assert.Equal("value$.$", environmentDictionary["DOLLAR3_D"]);
+			Assert.Equal("value$$", environmentDictionary["DOLLAR4_D"]);
 
-        [Fact]
+            // Validate that the environment is not loaded 
+			Assert.Null(Environment.GetEnvironmentVariable("TEST"));
+			Assert.Null(Environment.GetEnvironmentVariable("TEST1"));
+			Assert.Null(Environment.GetEnvironmentVariable("TEST2"));
+			Assert.Null(Environment.GetEnvironmentVariable("TEST3"));
+			Assert.Null(Environment.GetEnvironmentVariable("TEST4"));
+                  
+			Assert.Null(Environment.GetEnvironmentVariable("TEST5_DOUBLE"));
+			Assert.Null(Environment.GetEnvironmentVariable("TEST5_SINGLE"));
+			Assert.Null(Environment.GetEnvironmentVariable("TEST5_UNQUOTED"));
+                  
+			// not.Null interpolated values will keep whitespace! (as they should, esp if surrounding them with other values)
+			Assert.Null(Environment.GetEnvironmentVariable("TEST_UNQUOTED_WITH_INTERPOLATED_SURROUNDING_SPACES"));
+                  
+			Assert.Null(Environment.GetEnvironmentVariable("FIRST_KEY"));
+			Assert.Null(Environment.GetEnvironmentVariable("SECOND_KEY"));
+			// EXI.NullENVIRONMENT_VARIABLE already set to "value"
+			Assert.Null(Environment.GetEnvironmentVariable("THIRD_KEY"));
+			// DNE.Nulloes not exist (has no value)
+			Assert.Null(Environment.GetEnvironmentVariable("FOURTH_KEY"));
+                  
+			Assert.Null(Environment.GetEnvironmentVariable("GROUP_FILTER_REGEX"));
+                  
+			Assert.Null(Environment.GetEnvironmentVariable("DOLLAR1_U"));
+			Assert.Null(Environment.GetEnvironmentVariable("DOLLAR2_U"));
+			Assert.Null(Environment.GetEnvironmentVariable("DOLLAR3_U"));
+			Assert.Null(Environment.GetEnvironmentVariable("DOLLAR4_U"));
+                  
+			Assert.Null(Environment.GetEnvironmentVariable("DOLLAR1_S"));
+			Assert.Null(Environment.GetEnvironmentVariable("DOLLAR2_S"));
+			Assert.Null(Environment.GetEnvironmentVariable("DOLLAR3_S"));
+			Assert.Null(Environment.GetEnvironmentVariable("DOLLAR4_S"));
+                  
+			Assert.Null(Environment.GetEnvironmentVariable("DOLLAR1_D"));
+			Assert.Null(Environment.GetEnvironmentVariable("DOLLAR2_D"));
+			Assert.Null(Environment.GetEnvironmentVariable("DOLLAR3_D"));
+			Assert.Null(Environment.GetEnvironmentVariable("DOLLAR4_D"));
+		}
+
+		[Fact]
         public void QuotedHashTest()
         {
             DotNetEnv.Env.Load("./.env_quoted_hash");

--- a/test/DotNetEnv.Tests/EnvTests.cs
+++ b/test/DotNetEnv.Tests/EnvTests.cs
@@ -163,136 +163,136 @@ namespace DotNetEnv.Tests
             Assert.Equal(IsWindows ? "lower" : null, Environment.GetEnvironmentVariable("CASING"));
         }
 
-		[Fact]
-		public void ParseInterpolatedTest()
-		{
-			System.Environment.SetEnvironmentVariable("EXISTING_ENVIRONMENT_VARIABLE", "value");
-			System.Environment.SetEnvironmentVariable("DNE_VAR", null);
-			DotNetEnv.Env.Load("./.env_embedded");
-			Assert.Equal("test", Environment.GetEnvironmentVariable("TEST"));
-			Assert.Equal("test1", Environment.GetEnvironmentVariable("TEST1"));
-			Assert.Equal("test", Environment.GetEnvironmentVariable("TEST2"));
-			Assert.Equal("testtest", Environment.GetEnvironmentVariable("TEST3"));
-			Assert.Equal("testtest1", Environment.GetEnvironmentVariable("TEST4"));
+        [Fact]
+        public void ParseInterpolatedTest()
+        {
+            System.Environment.SetEnvironmentVariable("EXISTING_ENVIRONMENT_VARIABLE", "value");
+            System.Environment.SetEnvironmentVariable("DNE_VAR", null);
+            DotNetEnv.Env.Load("./.env_embedded");
+            Assert.Equal("test", Environment.GetEnvironmentVariable("TEST"));
+            Assert.Equal("test1", Environment.GetEnvironmentVariable("TEST1"));
+            Assert.Equal("test", Environment.GetEnvironmentVariable("TEST2"));
+            Assert.Equal("testtest", Environment.GetEnvironmentVariable("TEST3"));
+            Assert.Equal("testtest1", Environment.GetEnvironmentVariable("TEST4"));
 
-			Assert.Equal("test:testtest1 $$ '\" ® and test1", Environment.GetEnvironmentVariable("TEST5_DOUBLE"));
-			Assert.Equal("$TEST:$TEST4 \\$\\$ \" \\uae and $TEST1", Environment.GetEnvironmentVariable("TEST5_SINGLE"));
-			Assert.Equal("test:testtest1\\uaeandtest1", Environment.GetEnvironmentVariable("TEST5_UNQUOTED"));
+            Assert.Equal("test:testtest1 $$ '\" ® and test1", Environment.GetEnvironmentVariable("TEST5_DOUBLE"));
+            Assert.Equal("$TEST:$TEST4 \\$\\$ \" \\uae and $TEST1", Environment.GetEnvironmentVariable("TEST5_SINGLE"));
+            Assert.Equal("test:testtest1\\uaeandtest1", Environment.GetEnvironmentVariable("TEST5_UNQUOTED"));
 
-			// note that interpolated values will keep whitespace! (as they should, esp if surrounding them with other values)
-			Assert.Equal(" surrounded by spaces ", Environment.GetEnvironmentVariable("TEST_UNQUOTED_WITH_INTERPOLATED_SURROUNDING_SPACES"));
+            // note that interpolated values will keep whitespace! (as they should, esp if surrounding them with other values)
+            Assert.Equal(" surrounded by spaces ", Environment.GetEnvironmentVariable("TEST_UNQUOTED_WITH_INTERPOLATED_SURROUNDING_SPACES"));
 
-			Assert.Equal("value1", System.Environment.GetEnvironmentVariable("FIRST_KEY"));
-			Assert.Equal("value2andvalue1", System.Environment.GetEnvironmentVariable("SECOND_KEY"));
-			// EXISTING_ENVIRONMENT_VARIABLE already set to "value"
-			Assert.Equal("value;andvalue3", System.Environment.GetEnvironmentVariable("THIRD_KEY"));
-			// DNE_VAR does not exist (has no value)
-			Assert.Equal(";nope", System.Environment.GetEnvironmentVariable("FOURTH_KEY"));
+            Assert.Equal("value1", System.Environment.GetEnvironmentVariable("FIRST_KEY"));
+            Assert.Equal("value2andvalue1", System.Environment.GetEnvironmentVariable("SECOND_KEY"));
+            // EXISTING_ENVIRONMENT_VARIABLE already set to "value"
+            Assert.Equal("value;andvalue3", System.Environment.GetEnvironmentVariable("THIRD_KEY"));
+            // DNE_VAR does not exist (has no value)
+            Assert.Equal(";nope", System.Environment.GetEnvironmentVariable("FOURTH_KEY"));
 
-			Assert.Equal("^((?!Everyone).)*$", Environment.GetEnvironmentVariable("GROUP_FILTER_REGEX"));
+            Assert.Equal("^((?!Everyone).)*$", Environment.GetEnvironmentVariable("GROUP_FILTER_REGEX"));
 
-			Assert.Equal("value$", Environment.GetEnvironmentVariable("DOLLAR1_U"));
-			Assert.Equal("valuevalue$$", Environment.GetEnvironmentVariable("DOLLAR2_U"));
-			Assert.Equal("value$.$", Environment.GetEnvironmentVariable("DOLLAR3_U"));
-			Assert.Equal("value$$", Environment.GetEnvironmentVariable("DOLLAR4_U"));
+            Assert.Equal("value$", Environment.GetEnvironmentVariable("DOLLAR1_U"));
+            Assert.Equal("valuevalue$$", Environment.GetEnvironmentVariable("DOLLAR2_U"));
+            Assert.Equal("value$.$", Environment.GetEnvironmentVariable("DOLLAR3_U"));
+            Assert.Equal("value$$", Environment.GetEnvironmentVariable("DOLLAR4_U"));
 
-			Assert.Equal("value$", Environment.GetEnvironmentVariable("DOLLAR1_S"));
-			Assert.Equal("value$DOLLAR1_S$", Environment.GetEnvironmentVariable("DOLLAR2_S"));
-			Assert.Equal("value$.$", Environment.GetEnvironmentVariable("DOLLAR3_S"));
-			Assert.Equal("value$$", Environment.GetEnvironmentVariable("DOLLAR4_S"));
+            Assert.Equal("value$", Environment.GetEnvironmentVariable("DOLLAR1_S"));
+            Assert.Equal("value$DOLLAR1_S$", Environment.GetEnvironmentVariable("DOLLAR2_S"));
+            Assert.Equal("value$.$", Environment.GetEnvironmentVariable("DOLLAR3_S"));
+            Assert.Equal("value$$", Environment.GetEnvironmentVariable("DOLLAR4_S"));
 
-			Assert.Equal("value$", Environment.GetEnvironmentVariable("DOLLAR1_D"));
-			Assert.Equal("valuevalue$$", Environment.GetEnvironmentVariable("DOLLAR2_D"));
-			Assert.Equal("value$.$", Environment.GetEnvironmentVariable("DOLLAR3_D"));
-			Assert.Equal("value$$", Environment.GetEnvironmentVariable("DOLLAR4_D"));
-		}
+            Assert.Equal("value$", Environment.GetEnvironmentVariable("DOLLAR1_D"));
+            Assert.Equal("valuevalue$$", Environment.GetEnvironmentVariable("DOLLAR2_D"));
+            Assert.Equal("value$.$", Environment.GetEnvironmentVariable("DOLLAR3_D"));
+            Assert.Equal("value$$", Environment.GetEnvironmentVariable("DOLLAR4_D"));
+        }
 
-		[Fact]
-		public void ParseInterpolatedNoEnvVarsTest()
-		{
-			Environment.SetEnvironmentVariable("TEST", string.Empty);
-			Environment.SetEnvironmentVariable("TEST2", string.Empty);
-			Environment.SetEnvironmentVariable("EXISTING_ENVIRONMENT_VARIABLE", "value");
-			Environment.SetEnvironmentVariable("DNE_VAR", null);
-			var environmentDictionary = DotNetEnv.Env.NoEnvVars().Load("./.env_embedded").ToDotEnvDictionary();
-			Assert.Equal("test", environmentDictionary["TEST"]);
-			Assert.Equal("test1", environmentDictionary["TEST1"]);
-			Assert.Equal("test", environmentDictionary["TEST2"]);
-			Assert.Equal("testtest", environmentDictionary["TEST3"]);
-			Assert.Equal("testtest1", environmentDictionary["TEST4"]);
+        [Fact]
+        public void ParseInterpolatedNoEnvVarsTest()
+        {
+            Environment.SetEnvironmentVariable("TEST", string.Empty);
+            Environment.SetEnvironmentVariable("TEST2", string.Empty);
+            Environment.SetEnvironmentVariable("EXISTING_ENVIRONMENT_VARIABLE", "value");
+            Environment.SetEnvironmentVariable("DNE_VAR", null);
+            var environmentDictionary = DotNetEnv.Env.NoEnvVars().Load("./.env_embedded").ToDotEnvDictionary();
+            Assert.Equal("test", environmentDictionary["TEST"]);
+            Assert.Equal("test1", environmentDictionary["TEST1"]);
+            Assert.Equal("test", environmentDictionary["TEST2"]);
+            Assert.Equal("testtest", environmentDictionary["TEST3"]);
+            Assert.Equal("testtest1", environmentDictionary["TEST4"]);
 
-			Assert.Equal("test:testtest1 $$ '\" ® and test1", environmentDictionary["TEST5_DOUBLE"]);
-			Assert.Equal("$TEST:$TEST4 \\$\\$ \" \\uae and $TEST1", environmentDictionary["TEST5_SINGLE"]);
-			Assert.Equal("test:testtest1\\uaeandtest1", environmentDictionary["TEST5_UNQUOTED"]);
+            Assert.Equal("test:testtest1 $$ '\" ® and test1", environmentDictionary["TEST5_DOUBLE"]);
+            Assert.Equal("$TEST:$TEST4 \\$\\$ \" \\uae and $TEST1", environmentDictionary["TEST5_SINGLE"]);
+            Assert.Equal("test:testtest1\\uaeandtest1", environmentDictionary["TEST5_UNQUOTED"]);
 
-			// note that interpolated values will keep whitespace! (as they should, esp if surrounding them with other values)
-			Assert.Equal(" surrounded by spaces ", environmentDictionary["TEST_UNQUOTED_WITH_INTERPOLATED_SURROUNDING_SPACES"]);
+            // note that interpolated values will keep whitespace! (as they should, esp if surrounding them with other values)
+            Assert.Equal(" surrounded by spaces ", environmentDictionary["TEST_UNQUOTED_WITH_INTERPOLATED_SURROUNDING_SPACES"]);
 
-			Assert.Equal("value1", environmentDictionary["FIRST_KEY"]);
-			Assert.Equal("value2andvalue1", environmentDictionary["SECOND_KEY"]);
-			// EXISTING_ENVIRONMENT_VARIABLE already set to "value"
-			Assert.Equal("value;andvalue3", environmentDictionary["THIRD_KEY"]);
-			// DNE_VAR does not exist (has no value)
-			Assert.Equal(";nope", environmentDictionary["FOURTH_KEY"]);
+            Assert.Equal("value1", environmentDictionary["FIRST_KEY"]);
+            Assert.Equal("value2andvalue1", environmentDictionary["SECOND_KEY"]);
+            // EXISTING_ENVIRONMENT_VARIABLE already set to "value"
+            Assert.Equal("value;andvalue3", environmentDictionary["THIRD_KEY"]);
+            // DNE_VAR does not exist (has no value)
+            Assert.Equal(";nope", environmentDictionary["FOURTH_KEY"]);
 
-			Assert.Equal("^((?!Everyone).)*$", environmentDictionary["GROUP_FILTER_REGEX"]);
+            Assert.Equal("^((?!Everyone).)*$", environmentDictionary["GROUP_FILTER_REGEX"]);
 
-			Assert.Equal("value$", environmentDictionary["DOLLAR1_U"]);
-			Assert.Equal("valuevalue$$", environmentDictionary["DOLLAR2_U"]);
-			Assert.Equal("value$.$", environmentDictionary["DOLLAR3_U"]);
-			Assert.Equal("value$$", environmentDictionary["DOLLAR4_U"]);
+            Assert.Equal("value$", environmentDictionary["DOLLAR1_U"]);
+            Assert.Equal("valuevalue$$", environmentDictionary["DOLLAR2_U"]);
+            Assert.Equal("value$.$", environmentDictionary["DOLLAR3_U"]);
+            Assert.Equal("value$$", environmentDictionary["DOLLAR4_U"]);
 
-			Assert.Equal("value$", environmentDictionary["DOLLAR1_S"]);
-			Assert.Equal("value$DOLLAR1_S$", environmentDictionary["DOLLAR2_S"]);
-			Assert.Equal("value$.$", environmentDictionary["DOLLAR3_S"]);
-			Assert.Equal("value$$", environmentDictionary["DOLLAR4_S"]);
+            Assert.Equal("value$", environmentDictionary["DOLLAR1_S"]);
+            Assert.Equal("value$DOLLAR1_S$", environmentDictionary["DOLLAR2_S"]);
+            Assert.Equal("value$.$", environmentDictionary["DOLLAR3_S"]);
+            Assert.Equal("value$$", environmentDictionary["DOLLAR4_S"]);
 
-			Assert.Equal("value$", environmentDictionary["DOLLAR1_D"]);
-			Assert.Equal("valuevalue$$", environmentDictionary["DOLLAR2_D"]);
-			Assert.Equal("value$.$", environmentDictionary["DOLLAR3_D"]);
-			Assert.Equal("value$$", environmentDictionary["DOLLAR4_D"]);
+            Assert.Equal("value$", environmentDictionary["DOLLAR1_D"]);
+            Assert.Equal("valuevalue$$", environmentDictionary["DOLLAR2_D"]);
+            Assert.Equal("value$.$", environmentDictionary["DOLLAR3_D"]);
+            Assert.Equal("value$$", environmentDictionary["DOLLAR4_D"]);
 
-			// Validate that the environment is not loaded 
-			Assert.Null(Environment.GetEnvironmentVariable("TEST"));
-			Assert.Null(Environment.GetEnvironmentVariable("TEST1"));
-			Assert.Null(Environment.GetEnvironmentVariable("TEST2"));
-			Assert.Null(Environment.GetEnvironmentVariable("TEST3"));
-			Assert.Null(Environment.GetEnvironmentVariable("TEST4"));
+            // Validate that the environment is not loaded 
+            Assert.Null(Environment.GetEnvironmentVariable("TEST"));
+            Assert.Null(Environment.GetEnvironmentVariable("TEST1"));
+            Assert.Null(Environment.GetEnvironmentVariable("TEST2"));
+            Assert.Null(Environment.GetEnvironmentVariable("TEST3"));
+            Assert.Null(Environment.GetEnvironmentVariable("TEST4"));
 
-			Assert.Null(Environment.GetEnvironmentVariable("TEST5_DOUBLE"));
-			Assert.Null(Environment.GetEnvironmentVariable("TEST5_SINGLE"));
-			Assert.Null(Environment.GetEnvironmentVariable("TEST5_UNQUOTED"));
+            Assert.Null(Environment.GetEnvironmentVariable("TEST5_DOUBLE"));
+            Assert.Null(Environment.GetEnvironmentVariable("TEST5_SINGLE"));
+            Assert.Null(Environment.GetEnvironmentVariable("TEST5_UNQUOTED"));
 
-			// not.Null interpolated values will keep whitespace! (as they should, esp if surrounding them with other values)
-			Assert.Null(Environment.GetEnvironmentVariable("TEST_UNQUOTED_WITH_INTERPOLATED_SURROUNDING_SPACES"));
+            // not.Null interpolated values will keep whitespace! (as they should, esp if surrounding them with other values)
+            Assert.Null(Environment.GetEnvironmentVariable("TEST_UNQUOTED_WITH_INTERPOLATED_SURROUNDING_SPACES"));
 
-			Assert.Null(Environment.GetEnvironmentVariable("FIRST_KEY"));
-			Assert.Null(Environment.GetEnvironmentVariable("SECOND_KEY"));
-			// EXI.NullENVIRONMENT_VARIABLE already set to "value"
-			Assert.Null(Environment.GetEnvironmentVariable("THIRD_KEY"));
-			// DNE.Nulloes not exist (has no value)
-			Assert.Null(Environment.GetEnvironmentVariable("FOURTH_KEY"));
+            Assert.Null(Environment.GetEnvironmentVariable("FIRST_KEY"));
+            Assert.Null(Environment.GetEnvironmentVariable("SECOND_KEY"));
+            // EXI.NullENVIRONMENT_VARIABLE already set to "value"
+            Assert.Null(Environment.GetEnvironmentVariable("THIRD_KEY"));
+            // DNE.Nulloes not exist (has no value)
+            Assert.Null(Environment.GetEnvironmentVariable("FOURTH_KEY"));
 
-			Assert.Null(Environment.GetEnvironmentVariable("GROUP_FILTER_REGEX"));
+            Assert.Null(Environment.GetEnvironmentVariable("GROUP_FILTER_REGEX"));
 
-			Assert.Null(Environment.GetEnvironmentVariable("DOLLAR1_U"));
-			Assert.Null(Environment.GetEnvironmentVariable("DOLLAR2_U"));
-			Assert.Null(Environment.GetEnvironmentVariable("DOLLAR3_U"));
-			Assert.Null(Environment.GetEnvironmentVariable("DOLLAR4_U"));
+            Assert.Null(Environment.GetEnvironmentVariable("DOLLAR1_U"));
+            Assert.Null(Environment.GetEnvironmentVariable("DOLLAR2_U"));
+            Assert.Null(Environment.GetEnvironmentVariable("DOLLAR3_U"));
+            Assert.Null(Environment.GetEnvironmentVariable("DOLLAR4_U"));
 
-			Assert.Null(Environment.GetEnvironmentVariable("DOLLAR1_S"));
-			Assert.Null(Environment.GetEnvironmentVariable("DOLLAR2_S"));
-			Assert.Null(Environment.GetEnvironmentVariable("DOLLAR3_S"));
-			Assert.Null(Environment.GetEnvironmentVariable("DOLLAR4_S"));
+            Assert.Null(Environment.GetEnvironmentVariable("DOLLAR1_S"));
+            Assert.Null(Environment.GetEnvironmentVariable("DOLLAR2_S"));
+            Assert.Null(Environment.GetEnvironmentVariable("DOLLAR3_S"));
+            Assert.Null(Environment.GetEnvironmentVariable("DOLLAR4_S"));
 
-			Assert.Null(Environment.GetEnvironmentVariable("DOLLAR1_D"));
-			Assert.Null(Environment.GetEnvironmentVariable("DOLLAR2_D"));
-			Assert.Null(Environment.GetEnvironmentVariable("DOLLAR3_D"));
-			Assert.Null(Environment.GetEnvironmentVariable("DOLLAR4_D"));
-		}
+            Assert.Null(Environment.GetEnvironmentVariable("DOLLAR1_D"));
+            Assert.Null(Environment.GetEnvironmentVariable("DOLLAR2_D"));
+            Assert.Null(Environment.GetEnvironmentVariable("DOLLAR3_D"));
+            Assert.Null(Environment.GetEnvironmentVariable("DOLLAR4_D"));
+        }
 
-		[Fact]
-		public void QuotedHashTest()
+        [Fact]
+        public void QuotedHashTest()
         {
             DotNetEnv.Env.Load("./.env_quoted_hash");
             Assert.Equal("1234#not_comment", Environment.GetEnvironmentVariable("QTEST0"));

--- a/test/DotNetEnv.Tests/EnvTests.cs
+++ b/test/DotNetEnv.Tests/EnvTests.cs
@@ -18,7 +18,7 @@ namespace DotNetEnv.Tests
             DotNetEnv.Env.Load();
             Assert.Equal("Toni", Environment.GetEnvironmentVariable("NAME"));
             // unfortunately .NET removes empty env vars -- there can NEVER be an empty string env var value
-            //  https://msdn.microsoft.com/en-us/library/z46c489x(v=vs.110).aspx#Remarks
+            // https://msdn.microsoft.com/en-us/library/z46c489x(v=vs.110).aspx#Remarks
             Assert.Null(Environment.GetEnvironmentVariable("EMPTY"));
             Assert.Equal("'", Environment.GetEnvironmentVariable("QUOTE"));
             Assert.Equal("https://github.com/tonerdo", Environment.GetEnvironmentVariable("URL"));
@@ -210,7 +210,9 @@ namespace DotNetEnv.Tests
 		[Fact]
 		public void ParseInterpolatedNoEnvVarsTest()
 		{
-			Environment.SetEnvironmentVariable("EXISTING_ENVIRONMENT_VARIABLE", "value");
+            Environment.SetEnvironmentVariable("TEST", string.Empty);
+            Environment.SetEnvironmentVariable("TEST2", string.Empty);
+            Environment.SetEnvironmentVariable("EXISTING_ENVIRONMENT_VARIABLE", "value");
 			Environment.SetEnvironmentVariable("DNE_VAR", null);
 			var environmentDictionary = DotNetEnv.Env.NoEnvVars().Load("./.env_embedded").ToDotEnvDictionary();
 			Assert.Equal("test", environmentDictionary["TEST"]);
@@ -252,7 +254,7 @@ namespace DotNetEnv.Tests
 
             // Validate that the environment is not loaded 
 			Assert.Null(Environment.GetEnvironmentVariable("TEST"));
-			Assert.Null(Environment.GetEnvironmentVariable("TEST1"));
+            Assert.Null(Environment.GetEnvironmentVariable("TEST1"));
 			Assert.Null(Environment.GetEnvironmentVariable("TEST2"));
 			Assert.Null(Environment.GetEnvironmentVariable("TEST3"));
 			Assert.Null(Environment.GetEnvironmentVariable("TEST4"));
@@ -343,8 +345,8 @@ base64
             Assert.Equal("extra already here value", Environment.GetEnvironmentVariable("KEY_DOUBLE"));
             Assert.Equal("extraalready herevalue", Environment.GetEnvironmentVariable("KEY_UNQUOTED"));
             Assert.Equal("value#notcomment", Environment.GetEnvironmentVariable("KEY_UNQUOTED_HASH"));
-            Assert.Equal("value\nand more", Environment.GetEnvironmentVariable("KEY_MULTILINE"));
-            Assert.Equal("#not_comment\nline2", Environment.GetEnvironmentVariable("OTHER_MULTILINE"));
+            Assert.Equal("value\r\nand more", Environment.GetEnvironmentVariable("KEY_MULTILINE"));
+            Assert.Equal("#not_comment\r\nline2", Environment.GetEnvironmentVariable("OTHER_MULTILINE"));
 
             Assert.Equal("value", Environment.GetEnvironmentVariable("WHITE_PRE"));
             Assert.Equal("value", Environment.GetEnvironmentVariable("WHITE_POST"));

--- a/test/DotNetEnv.Tests/ParserTests.cs
+++ b/test/DotNetEnv.Tests/ParserTests.cs
@@ -518,7 +518,7 @@ ENVVAR_TEST = ' yahooooo '
             expecteds = new[] {
                 new KeyValuePair<string, string>("EV_DNE", "x y z"),
                 new KeyValuePair<string, string>("EV_TEST_1", "日 $ENVVAR_TEST 本"),
-                new KeyValuePair<string, string>("EV_TEST_2", "☠\n®"),
+                new KeyValuePair<string, string>("EV_TEST_2", "☠\r\n®"),
                 new KeyValuePair<string, string>("ENVVAR_TEST", " yahooooo "),
             };
             testParse(expecteds, contents);


### PR DESCRIPTION
I would expect this to work like `ParseInterpolatedTest` but it does not replace the enviroment variables correctly. Now it does.