### PR TITLE
store fakeenvvar dict for interpolation in NoEnvVars() mode

### DIFF
--- a/src/DotNetEnv/Env.cs
+++ b/src/DotNetEnv/Env.cs
@@ -10,6 +10,8 @@ namespace DotNetEnv
     {
         public const string DEFAULT_ENVFILENAME = ".env";
 
+        public static Dictionary<string, string> FakeEnvVars = new Dictionary<string, string>();
+
         public static IEnumerable<KeyValuePair<string, string>> LoadMulti (string[] paths, LoadOptions options = null)
         {
             return paths.Aggregate(

--- a/src/DotNetEnv/IValue.cs
+++ b/src/DotNetEnv/IValue.cs
@@ -21,7 +21,8 @@ namespace DotNetEnv
 
         public string GetValue ()
         {
-            return Environment.GetEnvironmentVariable(_id) ?? string.Empty;
+            var val = Environment.GetEnvironmentVariable(_id);
+            return val ?? (Env.FakeEnvVars.TryGetValue(_id, out val) ? val : string.Empty);
         }
     }
 

--- a/src/DotNetEnv/Parsers.cs
+++ b/src/DotNetEnv/Parsers.cs
@@ -16,6 +16,10 @@ namespace DotNetEnv
 
         public static KeyValuePair<string, string> DoNotSetEnvVar (KeyValuePair<string, string> kvp)
         {
+            if (Env.FakeEnvVars.ContainsKey(kvp.Key)) {
+                Env.FakeEnvVars.Remove(kvp.Key);
+            }
+            Env.FakeEnvVars.Add(kvp.Key, kvp.Value);
             return kvp;
         }
 

--- a/test/DotNetEnv.Tests/EnvConfigurationTests.cs
+++ b/test/DotNetEnv.Tests/EnvConfigurationTests.cs
@@ -100,6 +100,7 @@ namespace DotNetEnv.Tests
 
             // Have to remove since it's recursive and can be set by the `EnvTests.cs`
             Environment.SetEnvironmentVariable("TEST4", null);
+            Env.FakeEnvVars.Clear();
 
             this.configuration = new ConfigurationBuilder()
                 .AddDotNetEnv("./.env_embedded")


### PR DESCRIPTION
Replaces https://github.com/tonerdo/dotnet-env/pull/96 and resolves https://github.com/tonerdo/dotnet-env/issues/92