### PR TITLE
Feature/decouple env vars

### DIFF
--- a/src/DotNetEnv/Configuration/EnvConfigurationProvider.cs
+++ b/src/DotNetEnv/Configuration/EnvConfigurationProvider.cs
@@ -21,28 +21,11 @@ namespace DotNetEnv.Configuration
 
         public override void Load()
         {
-            IEnumerable<KeyValuePair<string, string>> values;
-            if (paths == null)
-            {
-                values = Env.Load(options: options);
-            }
-            else
-            {
-                if (paths.Length == 1)
-                {
-                    values = Env.Load(paths[0], options);
-                }
-                else
-                {
-                    values = Env.LoadMulti(paths, options);
-                }
-            }
+            var values = paths == null
+                ? Env.Load(options: options)
+                : Env.LoadMulti(paths, options);
 
-            // Since the Load method does not take care of clobberring, We have to check it here!
-            var dictionaryOption = options.ClobberExistingVars ? CreateDictionaryOption.TakeLast : CreateDictionaryOption.TakeFirst;
-            var dotEnvDictionary = values.ToDotEnvDictionary(dictionaryOption);
-
-            foreach (var value in dotEnvDictionary)
+            foreach (var value in values)
                 Data[NormalizeKey(value.Key)] = value.Value;
         }
 

--- a/src/DotNetEnv/Configuration/EnvConfigurationProvider.cs
+++ b/src/DotNetEnv/Configuration/EnvConfigurationProvider.cs
@@ -42,11 +42,6 @@ namespace DotNetEnv.Configuration
             var dictionaryOption = options.ClobberExistingVars ? CreateDictionaryOption.TakeLast : CreateDictionaryOption.TakeFirst;
             var dotEnvDictionary = values.ToDotEnvDictionary(dictionaryOption);
 
-            if (!options.ClobberExistingVars)
-                foreach (string key in Environment.GetEnvironmentVariables().Keys)
-                    if (dotEnvDictionary.ContainsKey(key))
-                        dotEnvDictionary[key] = Environment.GetEnvironmentVariable(key);
-
             foreach (var value in dotEnvDictionary)
                 Data[NormalizeKey(value.Key)] = value.Value;
         }

--- a/src/DotNetEnv/Env.cs
+++ b/src/DotNetEnv/Env.cs
@@ -91,11 +91,10 @@ namespace DotNetEnv
                 ? CreateDictionaryOption.TakeLast
                 : CreateDictionaryOption.TakeFirst;
 
-            Parsers.EnvVarSnapshot =
-                new ConcurrentDictionary<string, string>(envVarSnapshot.Concat(previousValues)
-                    .ToDotEnvDictionary(dictionaryOption));
+            var actualValues = new ConcurrentDictionary<string, string>(envVarSnapshot.Concat(previousValues)
+                .ToDotEnvDictionary(dictionaryOption));
 
-            var pairs = Parsers.ParseDotenvFile(contents, options.ClobberExistingVars);
+            var pairs = Parsers.ParseDotenvFile(contents, options.ClobberExistingVars, actualValues);
 
             // for NoClobber, remove pairs which are exactly contained in previousValues or present in EnvironmentVariables
             var unClobberedPairs = (options.ClobberExistingVars

--- a/src/DotNetEnv/Env.cs
+++ b/src/DotNetEnv/Env.cs
@@ -13,7 +13,8 @@ namespace DotNetEnv
     {
         public const string DEFAULT_ENVFILENAME = ".env";
 
-        public static IEnumerable<KeyValuePair<string, string>> LoadMulti (string[] paths, LoadOptions options = null, IEnumerable<KeyValuePair<string, string>> additionalValues = null)
+        public static IEnumerable<KeyValuePair<string, string>> LoadMulti(string[] paths, LoadOptions options = null,
+            IEnumerable<KeyValuePair<string, string>> additionalValues = null)
         {
             return paths.Aggregate(
                 additionalValues?.ToArray() ?? Array.Empty<KeyValuePair<string, string>>(),
@@ -76,56 +77,53 @@ namespace DotNetEnv
             if (options == null) options = LoadOptions.DEFAULT;
 
             additionalValues = additionalValues?.ToArray() ?? Array.Empty<KeyValuePair<string, string>>();
+
             var envVarSnapshot = Environment.GetEnvironmentVariables().Cast<DictionaryEntry>()
                 .Select(entry => new KeyValuePair<string, string>(entry.Key.ToString(), entry.Value.ToString()))
                 .ToArray();
 
-            var dictionaryOption = options.ClobberExistingVars ? CreateDictionaryOption.TakeLast : CreateDictionaryOption.TakeFirst;
+            var dictionaryOption = options.ClobberExistingVars
+                ? CreateDictionaryOption.TakeLast
+                : CreateDictionaryOption.TakeFirst;
+
             Parsers.EnvVarSnapshot =
                 new ConcurrentDictionary<string, string>(envVarSnapshot.Concat(additionalValues)
                     .ToDotEnvDictionary(dictionaryOption));
 
-            var pairs = Parsers.ParseDotenvFile(contents, options.ClobberExistingVars).ToList();
+            var pairs = Parsers.ParseDotenvFile(contents, options.ClobberExistingVars);
+
+            // for NoClobber, remove pairs which are exactly contained in additionalValues or present in EnvironmentVariables
+            var unClobberedPairs = (options.ClobberExistingVars
+                    ? pairs
+                    : pairs.Where(p =>
+                        additionalValues.All(pv => pv.Key != p.Key) &&
+                        Environment.GetEnvironmentVariable(p.Key) == null))
+                .ToArray();
 
             if (options.SetEnvVars)
-                SetEnvVars(pairs, options.ClobberExistingVars);
-
-            if (options.ClobberExistingVars)
-                return additionalValues.Concat(pairs);
-
-            // prepend the pairs with all EnvVars with keys, which are present in pairs
-            // when taking first elements (noClobber) you get the EnvVars first, but all values from Env are still present in the result
-            // one could argue, that at this place we should return a dictionary instead; if someone needs "raw" values he can use ParseDotenvFile directly;
-            return pairs
-                .Join(envVarSnapshot
-                    , pair => pair.Key
-                    , envVar => envVar.Key
-                    , (pair, envVar) => envVar)
-                .Concat(additionalValues)
-                .Concat(pairs);
-        }
-
-        private static void SetEnvVars(List<KeyValuePair<string, string>> pairs, bool clobberExistingVars)
-        {
-            foreach (var pair in pairs)
-                if (clobberExistingVars || Environment.GetEnvironmentVariable(pair.Key) == null)
+                foreach (var pair in unClobberedPairs)
                     Environment.SetEnvironmentVariable(pair.Key, pair.Value);
+
+            return unClobberedPairs.ToDotEnvDictionary(dictionaryOption);
         }
 
-        public static string GetString (string key, string fallback = default(string)) =>
+        public static string GetString(string key, string fallback = default(string)) =>
             Environment.GetEnvironmentVariable(key) ?? fallback;
 
-        public static bool GetBool (string key, bool fallback = default(bool)) =>
+        public static bool GetBool(string key, bool fallback = default(bool)) =>
             bool.TryParse(Environment.GetEnvironmentVariable(key), out var value) ? value : fallback;
 
-        public static int GetInt (string key, int fallback = default(int)) =>
+        public static int GetInt(string key, int fallback = default(int)) =>
             int.TryParse(Environment.GetEnvironmentVariable(key), out var value) ? value : fallback;
 
-        public static double GetDouble (string key, double fallback = default(double)) =>
-            double.TryParse(Environment.GetEnvironmentVariable(key), NumberStyles.Any, CultureInfo.InvariantCulture, out var value) ? value : fallback;
+        public static double GetDouble(string key, double fallback = default(double)) =>
+            double.TryParse(Environment.GetEnvironmentVariable(key), NumberStyles.Any, CultureInfo.InvariantCulture,
+                out var value)
+                ? value
+                : fallback;
 
-        public static LoadOptions NoEnvVars () => LoadOptions.NoEnvVars();
-        public static LoadOptions NoClobber () => LoadOptions.NoClobber();
-        public static LoadOptions TraversePath () => LoadOptions.TraversePath();
+        public static LoadOptions NoEnvVars() => LoadOptions.NoEnvVars();
+        public static LoadOptions NoClobber() => LoadOptions.NoClobber();
+        public static LoadOptions TraversePath() => LoadOptions.TraversePath();
     }
 }

--- a/src/DotNetEnv/Env.cs
+++ b/src/DotNetEnv/Env.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Linq;
 using System.Collections.Generic;
@@ -11,7 +12,7 @@ namespace DotNetEnv
     {
         public const string DEFAULT_ENVFILENAME = ".env";
 
-        public static ConcurrentDictionary<string, string> FakeEnvVars = new ConcurrentDictionary<string, string>();
+        public static ConcurrentDictionary<string, string> EnvVarSnapshot = new ConcurrentDictionary<string, string>();
 
         public static IEnumerable<KeyValuePair<string, string>> LoadMulti (string[] paths, LoadOptions options = null)
         {
@@ -69,6 +70,10 @@ namespace DotNetEnv
         public static IEnumerable<KeyValuePair<string, string>> LoadContents (string contents, LoadOptions options = null)
         {
             if (options == null) options = LoadOptions.DEFAULT;
+
+            EnvVarSnapshot = new ConcurrentDictionary<string, string>(Environment.GetEnvironmentVariables()
+                .Cast<DictionaryEntry>()
+                .ToDictionary(kvp => kvp.Key.ToString(), kvp => kvp.Value.ToString()));
 
             if (options.SetEnvVars)
             {

--- a/src/DotNetEnv/IInterpolationHandler.cs
+++ b/src/DotNetEnv/IInterpolationHandler.cs
@@ -2,14 +2,6 @@ using System;
 
 namespace DotNetEnv
 {
-    static class LookupHelper
-    {
-        public static string GetEnvironmentVariable(string key)
-        {
-            return Parsers.ActualValuesSnapshot.TryGetValue(key, out var fakeVal) ? fakeVal : null;
-        }
-    }
-
     public interface IInterpolationHandler
     {
         string Handle(string key);
@@ -19,13 +11,13 @@ namespace DotNetEnv
     {
         public string Handle(string key)
         {
-            return LookupHelper.GetEnvironmentVariable(key) ?? string.Empty;
+            return Parsers.CurrentValueProvider.TryGetValue(key, out var value) ? value : string.Empty;
         }
     }
 
     public class DefaultInterpolationHandler : IInterpolationHandler
     {
-        readonly string _defaultValue;
+        private readonly string _defaultValue;
 
         public DefaultInterpolationHandler(string defaultValue)
         {
@@ -34,8 +26,7 @@ namespace DotNetEnv
 
         public string Handle(string key)
         {
-            var val = LookupHelper.GetEnvironmentVariable(key);
-            return val ?? _defaultValue;
+            return Parsers.CurrentValueProvider.TryGetValue(key, out var value) ? value : _defaultValue;
         }
     }
 
@@ -43,8 +34,9 @@ namespace DotNetEnv
     {
         public string Handle(string key)
         {
-            var val = LookupHelper.GetEnvironmentVariable(key);
-            return val ?? throw new Exception($"Required environment variable '{key}' is not set.");
+            return Parsers.CurrentValueProvider.TryGetValue(key, out var value)
+                ? value
+                : throw new Exception($"Required environment variable '{key}' is not set.");
         }
     }
 
@@ -59,8 +51,7 @@ namespace DotNetEnv
 
         public string Handle(string key)
         {
-            var val = LookupHelper.GetEnvironmentVariable(key);
-            return val != null
+            return Parsers.CurrentValueProvider.TryGetValue(key, out _)
                 ? _replacementValue
                 : string.Empty;
         }

--- a/src/DotNetEnv/IInterpolationHandler.cs
+++ b/src/DotNetEnv/IInterpolationHandler.cs
@@ -6,13 +6,7 @@ namespace DotNetEnv
     {
         public static string GetEnvironmentVariable(string key)
         {
-            var val = Environment.GetEnvironmentVariable(key);
-            if (val == null && Env.FakeEnvVars.TryGetValue(key, out var fakeVal))
-            {
-                return fakeVal;
-            }
-
-            return val;
+            return Env.EnvVarSnapshot.TryGetValue(key, out var fakeVal) ? fakeVal : null;
         }
     }
 

--- a/src/DotNetEnv/IInterpolationHandler.cs
+++ b/src/DotNetEnv/IInterpolationHandler.cs
@@ -6,7 +6,7 @@ namespace DotNetEnv
     {
         public static string GetEnvironmentVariable(string key)
         {
-            return Parsers.EnvVarSnapshot.TryGetValue(key, out var fakeVal) ? fakeVal : null;
+            return Parsers.ActualValuesSnapshot.TryGetValue(key, out var fakeVal) ? fakeVal : null;
         }
     }
 

--- a/src/DotNetEnv/IInterpolationHandler.cs
+++ b/src/DotNetEnv/IInterpolationHandler.cs
@@ -6,7 +6,7 @@ namespace DotNetEnv
     {
         public static string GetEnvironmentVariable(string key)
         {
-            return Env.EnvVarSnapshot.TryGetValue(key, out var fakeVal) ? fakeVal : null;
+            return Parsers.EnvVarSnapshot.TryGetValue(key, out var fakeVal) ? fakeVal : null;
         }
     }
 

--- a/src/DotNetEnv/Parsers.cs
+++ b/src/DotNetEnv/Parsers.cs
@@ -15,12 +15,13 @@ namespace DotNetEnv
         public static KeyValuePair<string, string> SetEnvVar (KeyValuePair<string, string> kvp)
         {
             Environment.SetEnvironmentVariable(kvp.Key, kvp.Value);
+            Env.EnvVarSnapshot.AddOrUpdate(kvp.Key, kvp.Value, (key, oldValue) =>  kvp.Value);
             return kvp;
         }
 
         public static KeyValuePair<string, string> DoNotSetEnvVar (KeyValuePair<string, string> kvp)
         {
-            Env.FakeEnvVars.AddOrUpdate(kvp.Key, kvp.Value, (_, v) => v);
+            Env.EnvVarSnapshot.AddOrUpdate(kvp.Key, kvp.Value, (key, oldValue) =>  kvp.Value);
             return kvp;
         }
 
@@ -29,6 +30,7 @@ namespace DotNetEnv
             if (Environment.GetEnvironmentVariable(kvp.Key) == null)
             {
                 Environment.SetEnvironmentVariable(kvp.Key, kvp.Value);
+                Env.EnvVarSnapshot.AddOrUpdate(kvp.Key, kvp.Value, (key, oldValue) =>  kvp.Value);
             }
             // not sure if maybe should return something different if avoided clobber... (current value?)
             // probably not since the point is to return what the dotenv file reported, but it's arguable

--- a/src/DotNetEnv/ValueProvider.cs
+++ b/src/DotNetEnv/ValueProvider.cs
@@ -81,10 +81,6 @@ namespace DotNetEnv
             _providers = providers;
         }
 
-        public override string GetValue(string key)
-            => (_clobberExisting ? _providers.Reverse() : _providers)
-                .Aggregate((string)null, (current, valueProvider) => current ?? valueProvider.GetValue(key));
-
         public override bool TryGetValue(string key, out string value)
         {
             foreach (var provider in _clobberExisting ? _providers.Reverse() : _providers)

--- a/src/DotNetEnv/ValueProvider.cs
+++ b/src/DotNetEnv/ValueProvider.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DotNetEnv
+{
+    internal interface IValueProvider
+    {
+        string GetValue(string key);
+        bool TryGetValue(string key, out string value);
+    }
+
+    internal abstract class ValueProvider : IValueProvider
+    {
+        public virtual string GetValue(string key) => TryGetValue(key, out var value)
+            ? value
+            : throw new KeyNotFoundException();
+
+        public abstract bool TryGetValue(string key, out string value);
+    }
+    internal class EnvironmentValueProvider : ValueProvider
+    {
+        public override bool TryGetValue(string key, out string value)
+        {
+            value = Environment.GetEnvironmentVariable(key);
+            return value != null;
+        }
+    }
+
+    internal class DictionaryValueProvider : ValueProvider
+    {
+        private readonly IDictionary<string, string> _keyValuePairs;
+
+        public DictionaryValueProvider(IDictionary<string, string> dictionary)
+            => _keyValuePairs = dictionary;
+
+        public override bool TryGetValue(string key, out string value) => _keyValuePairs.TryGetValue(key, out value);
+    }
+
+    internal class ChainedValueProvider : ValueProvider
+    {
+        private readonly bool _clobberExisting;
+        private readonly IValueProvider[] _providers;
+
+        public ChainedValueProvider(bool clobberExisting, params IValueProvider[] providers)
+        {
+            _clobberExisting = clobberExisting;
+            _providers = providers;
+        }
+
+        public override string GetValue(string key)
+            => (_clobberExisting ? _providers.Reverse() : _providers)
+                .Aggregate((string)null, (current, valueProvider) => current ?? valueProvider.GetValue(key));
+
+        public override bool TryGetValue(string key, out string value)
+        {
+            foreach (var provider in _clobberExisting ? _providers.Reverse() : _providers)
+                if (provider.TryGetValue(key, out value))
+                    return true;
+
+            value = null;
+            return false;
+        }
+    }
+}

--- a/test/DotNetEnv.Tests/.env
+++ b/test/DotNetEnv.Tests/.env
@@ -1,4 +1,5 @@
 # test env file
+NAME=ClobberedToni
 NAME=Toni #inline comment
 EMPTY=
 QUOTE="'"
@@ -8,3 +9,4 @@ CONNECTION=user=test;password=secret
 PASSWORD=Google#Facebook
 SSL_CERT="SPECIAL STUFF---\nLONG-BASE64\ignore\"slash"
 ENVVAR_TEST=overridden
+INTERPOLATED_NAME=$NAME

--- a/test/DotNetEnv.Tests/.env2
+++ b/test/DotNetEnv.Tests/.env2
@@ -8,3 +8,5 @@ WHITELEAD='  leading white space followed by comment'  # comment
 UNICODE="\u00ae \U0001F680 日本"
 NAME=Other
 ENVVAR_TEST=overridden_2
+ClobberEnvVarTest=$ENVVAR_TEST
+UrlFromVariable=$URL

--- a/test/DotNetEnv.Tests/EnvConfigurationTests.cs
+++ b/test/DotNetEnv.Tests/EnvConfigurationTests.cs
@@ -117,8 +117,10 @@ namespace DotNetEnv.Tests
             Assert.Equal("value2", section["Key2"]);
         }
 
-        [Fact()]
-        public void AddSourceToBuilderAndParseInterpolatedTest()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void AddSourceToBuilderAndParseInterpolatedTest(bool setEnvVars)
         {
             Environment.SetEnvironmentVariable("EXISTING_ENVIRONMENT_VARIABLE", "value");
             Environment.SetEnvironmentVariable("DNE_VAR", null);
@@ -128,7 +130,7 @@ namespace DotNetEnv.Tests
             Env.FakeEnvVars.Clear();
 
             configuration = new ConfigurationBuilder()
-                .AddDotNetEnv("./.env_embedded")
+                .AddDotNetEnv("./.env_embedded", new LoadOptions(setEnvVars: setEnvVars))
                 .Build();
 
             Assert.Equal("test", configuration["TEST"]);

--- a/test/DotNetEnv.Tests/EnvConfigurationTests.cs
+++ b/test/DotNetEnv.Tests/EnvConfigurationTests.cs
@@ -106,7 +106,7 @@ namespace DotNetEnv.Tests
             Assert.Equal("Other", configuration["NAME"]);
             Assert.Equal("overridden_2", configuration["ENVVAR_TEST"]);
             Assert.Equal("overridden_2", configuration["ClobberEnvVarTest"]); // should contain ENVVAR_TEST from .env
-            Assert.Equal("https://github.com/tonerdo", configuration["UrlFromPreviousEnv"]); // should contain Url from .env
+            Assert.Equal("https://github.com/tonerdo", configuration["UrlFromVariable"]); // should contain Url from .env
         }
 
         [Fact]

--- a/test/DotNetEnv.Tests/EnvConfigurationTests.cs
+++ b/test/DotNetEnv.Tests/EnvConfigurationTests.cs
@@ -92,6 +92,21 @@ namespace DotNetEnv.Tests
 
             Assert.Equal("Toni", configuration["NAME"]);
             Assert.Equal("ENV value", configuration["ENVVAR_TEST"]);
+            Assert.Equal("ENV value", configuration["ClobberEnvVarTest"]); // should contain ENVVAR_TEST from EnvironmentVariable
+            Assert.Equal("https://github.com/tonerdo", configuration["UrlFromVariable"]); // should contain Url from .env
+        }
+
+        [Fact]
+        public void AddSourceToBuilderAndLoadMultiWithClobber()
+        {
+            configuration = new ConfigurationBuilder()
+                .AddDotNetEnvMulti(new[] { "./.env", "./.env2" }, LoadOptions.NoEnvVars())
+                .Build();
+
+            Assert.Equal("Other", configuration["NAME"]);
+            Assert.Equal("overridden_2", configuration["ENVVAR_TEST"]);
+            Assert.Equal("overridden_2", configuration["ClobberEnvVarTest"]); // should contain ENVVAR_TEST from .env
+            Assert.Equal("https://github.com/tonerdo", configuration["UrlFromPreviousEnv"]); // should contain Url from .env
         }
 
         [Fact]

--- a/test/DotNetEnv.Tests/EnvConfigurationTests.cs
+++ b/test/DotNetEnv.Tests/EnvConfigurationTests.cs
@@ -91,7 +91,7 @@ namespace DotNetEnv.Tests
                 .Build();
 
             Assert.Equal("Toni", configuration["NAME"]);
-            Assert.Equal("ENV value", configuration["ENVVAR_TEST"]);
+            Assert.Null(configuration["ENVVAR_TEST"]); // value from EnvironmentVariables is not contained for NoClobber
             Assert.Equal("ENV value", configuration["ClobberEnvVarTest"]); // should contain ENVVAR_TEST from EnvironmentVariable
             Assert.Equal("https://github.com/tonerdo", configuration["UrlFromVariable"]); // should contain Url from .env
         }

--- a/test/DotNetEnv.Tests/EnvConfigurationTests.cs
+++ b/test/DotNetEnv.Tests/EnvConfigurationTests.cs
@@ -142,7 +142,7 @@ namespace DotNetEnv.Tests
 
             // Have to remove since it's recursive and can be set by the `EnvTests.cs`
             Environment.SetEnvironmentVariable("TEST4", null);
-            Env.FakeEnvVars.Clear();
+            Env.EnvVarSnapshot.Clear();
 
             configuration = new ConfigurationBuilder()
                 .AddDotNetEnv("./.env_embedded", new LoadOptions(setEnvVars: setEnvVars))

--- a/test/DotNetEnv.Tests/EnvConfigurationTests.cs
+++ b/test/DotNetEnv.Tests/EnvConfigurationTests.cs
@@ -142,7 +142,6 @@ namespace DotNetEnv.Tests
 
             // Have to remove since it's recursive and can be set by the `EnvTests.cs`
             Environment.SetEnvironmentVariable("TEST4", null);
-            Env.EnvVarSnapshot.Clear();
 
             configuration = new ConfigurationBuilder()
                 .AddDotNetEnv("./.env_embedded", new LoadOptions(setEnvVars: setEnvVars))

--- a/test/DotNetEnv.Tests/EnvConfigurationTests.cs
+++ b/test/DotNetEnv.Tests/EnvConfigurationTests.cs
@@ -90,7 +90,7 @@ namespace DotNetEnv.Tests
                 .AddDotNetEnvMulti(new[] { "./.env", "./.env2" }, LoadOptions.NoEnvVars().NoClobber())
                 .Build();
 
-            Assert.Equal("Toni", configuration["NAME"]);
+            Assert.Equal("ClobberedToni", configuration["NAME"]);
             Assert.Null(configuration["ENVVAR_TEST"]); // value from EnvironmentVariables is not contained for NoClobber
             Assert.Equal("ENV value", configuration["ClobberEnvVarTest"]); // should contain ENVVAR_TEST from EnvironmentVariable
             Assert.Equal("https://github.com/tonerdo", configuration["UrlFromVariable"]); // should contain Url from .env

--- a/test/DotNetEnv.Tests/EnvTests.cs
+++ b/test/DotNetEnv.Tests/EnvTests.cs
@@ -148,6 +148,19 @@ namespace DotNetEnv.Tests
         }
 
         [Fact]
+        public void LoadMultiTestNoEnvVars()
+        {
+            var pairs = DotNetEnv.Env.NoEnvVars().LoadMulti(new[] { "./.env", "./.env2" });
+            Assert.Equal("Other", pairs.LastOrDefault(x => x.Key == "NAME").Value);
+            Environment.SetEnvironmentVariable("NAME", null);
+            pairs = DotNetEnv.Env.NoEnvVars().NoClobber().LoadMulti(new[] { "./.env", "./.env2" });
+            Assert.Equal("Toni", pairs.FirstOrDefault(x => x.Key == "NAME").Value);
+            Environment.SetEnvironmentVariable("NAME", "Person");
+            pairs = DotNetEnv.Env.NoEnvVars().NoClobber().LoadMulti(new[] { "./.env", "./.env2" });
+            Assert.Equal("Person", pairs.FirstOrDefault(x => x.Key == "NAME").Value);
+        }
+
+        [Fact]
         public void LoadNoClobberTest()
         {
             var expected = "totally the original value";

--- a/test/DotNetEnv.Tests/EnvTests.cs
+++ b/test/DotNetEnv.Tests/EnvTests.cs
@@ -157,7 +157,7 @@ namespace DotNetEnv.Tests
             Assert.Equal("Toni", pairs.FirstOrDefault(x => x.Key == "NAME").Value);
             Environment.SetEnvironmentVariable("NAME", "Person");
             pairs = DotNetEnv.Env.NoEnvVars().NoClobber().LoadMulti(new[] { "./.env", "./.env2" });
-            Assert.Equal("Person", pairs.FirstOrDefault(x => x.Key == "NAME").Value);
+            Assert.Null(pairs.FirstOrDefault(x => x.Key == "NAME").Value); // value from EnvironmentVariables is not contained with NoClobber
         }
 
         [Fact]
@@ -403,16 +403,11 @@ base64
             Environment.SetEnvironmentVariable("NVAR2", "_nvar2_");
 
             var kvps = DotNetEnv.Env.Load("./.env_other").ToArray();
-            Assert.Equal(35, kvps.Length);
-            var dict = kvps.ToDotEnvDictionary();
+            Assert.Equal(34, kvps.Length);
 
-            // note that env vars get only the final assignment, but all are returned
             Assert.Equal("dupe2", Environment.GetEnvironmentVariable("DUPLICATE"));
-            Assert.Equal("dupe2", dict["DUPLICATE"]);
             Assert.Equal("DUPLICATE", kvps[0].Key);
-            Assert.Equal("DUPLICATE", kvps[1].Key);
-            Assert.Equal("dupe1", kvps[0].Value);
-            Assert.Equal("dupe2", kvps[1].Value);
+            Assert.Equal("dupe2", kvps[0].Value);
 
             Assert.Equal("bar", Environment.GetEnvironmentVariable("TEST_KEYWORD_1"));
             Assert.Equal("12345", Environment.GetEnvironmentVariable("TEST_KEYWORD_2"));

--- a/test/DotNetEnv.Tests/EnvTests.cs
+++ b/test/DotNetEnv.Tests/EnvTests.cs
@@ -15,6 +15,7 @@ namespace DotNetEnv.Tests
         private static string[] OldEnvVars = new string[]
         {
             "NAME",
+            "INTERPOLATED_NAME",
             "EMPTY",
             "QUOTE",
             "URL",
@@ -141,7 +142,7 @@ namespace DotNetEnv.Tests
             Assert.Equal("Other", Environment.GetEnvironmentVariable("NAME"));
             Environment.SetEnvironmentVariable("NAME", null);
             DotNetEnv.Env.NoClobber().LoadMulti(new[] { "./.env", "./.env2" });
-            Assert.Equal("Toni", Environment.GetEnvironmentVariable("NAME"));
+            Assert.Equal("ClobberedToni", Environment.GetEnvironmentVariable("NAME"));
             Environment.SetEnvironmentVariable("NAME", "Person");
             DotNetEnv.Env.NoClobber().LoadMulti(new[] { "./.env", "./.env2" });
             Assert.Equal("Person", Environment.GetEnvironmentVariable("NAME"));
@@ -154,7 +155,7 @@ namespace DotNetEnv.Tests
             Assert.Equal("Other", pairs.LastOrDefault(x => x.Key == "NAME").Value);
             Environment.SetEnvironmentVariable("NAME", null);
             pairs = DotNetEnv.Env.NoEnvVars().NoClobber().LoadMulti(new[] { "./.env", "./.env2" });
-            Assert.Equal("Toni", pairs.FirstOrDefault(x => x.Key == "NAME").Value);
+            Assert.Equal("ClobberedToni", pairs.FirstOrDefault(x => x.Key == "NAME").Value);
             Environment.SetEnvironmentVariable("NAME", "Person");
             pairs = DotNetEnv.Env.NoEnvVars().NoClobber().LoadMulti(new[] { "./.env", "./.env2" });
             Assert.Null(pairs.FirstOrDefault(x => x.Key == "NAME").Value); // value from EnvironmentVariables is not contained with NoClobber
@@ -168,13 +169,15 @@ namespace DotNetEnv.Tests
             Environment.SetEnvironmentVariable("URL", expected);
             DotNetEnv.Env.Load(options: new DotNetEnv.LoadOptions(clobberExistingVars: false));
             Assert.Equal(expected, Environment.GetEnvironmentVariable("URL"));
-            Assert.Equal("Toni", Environment.GetEnvironmentVariable("NAME"));
+            Assert.Equal("ClobberedToni", Environment.GetEnvironmentVariable("NAME"));
+            Assert.Equal("ClobberedToni", Environment.GetEnvironmentVariable("INTERPOLATED_NAME"));
 
             Environment.SetEnvironmentVariable("NAME", null);
             Environment.SetEnvironmentVariable("URL", "i'm going to be overwritten");
             DotNetEnv.Env.Load(options: new DotNetEnv.LoadOptions(clobberExistingVars: true));
             Assert.Equal("https://github.com/tonerdo", Environment.GetEnvironmentVariable("URL"));
             Assert.Equal("Toni", Environment.GetEnvironmentVariable("NAME"));
+            Assert.Equal("Toni", Environment.GetEnvironmentVariable("INTERPOLATED_NAME"));
         }
 
         [Fact]

--- a/test/DotNetEnv.Tests/Helper/UnicodeChars.cs
+++ b/test/DotNetEnv.Tests/Helper/UnicodeChars.cs
@@ -1,5 +1,7 @@
 namespace DotNetEnv.Tests.Helper;
 
+
+// C# wow that you can't handle 32 bit unicode as chars. wow. strings for 4 byte chars.
 public struct UnicodeChars
 {
     // https://stackoverflow.com/questions/602912/how-do-you-echo-a-4-digit-unicode-character-in-bash

--- a/test/DotNetEnv.Tests/Helper/UnicodeChars.cs
+++ b/test/DotNetEnv.Tests/Helper/UnicodeChars.cs
@@ -1,6 +1,5 @@
 namespace DotNetEnv.Tests.Helper;
 
-
 // C# wow that you can't handle 32 bit unicode as chars. wow. strings for 4 byte chars.
 public struct UnicodeChars
 {

--- a/test/DotNetEnv.Tests/ParserTests.cs
+++ b/test/DotNetEnv.Tests/ParserTests.cs
@@ -92,6 +92,7 @@ namespace DotNetEnv.Tests
         public void Utf32CharShouldParseUntilEnd(string expected, string input) =>
             Assert.Equal(expected, Parsers.Utf32Char.AtEnd().Parse(input));
 
+        [Theory]
         [InlineData("\b", "\\b")]
         [InlineData("'", "\\'")]
         [InlineData("\"", "\\\"")]
@@ -520,7 +521,5 @@ ENVVAR_TEST = ' yahooooo '
         [InlineData("EV_DNE=0\n1")]
         public void ParseDotenvFileShouldThrowOnContents(string invalidContents) =>
             Assert.Throws<ParseException>(() => Parsers.ParseDotenvFile(invalidContents));
-
-        // C# wow that you can't handle 32 bit unicode as chars. wow. strings for 4 byte chars.
     }
 }

--- a/test/DotNetEnv.Tests/ParserTests.cs
+++ b/test/DotNetEnv.Tests/ParserTests.cs
@@ -14,14 +14,14 @@ namespace DotNetEnv.Tests
     public class ParserTests
     {
         private const string EV_TEST = "ENVVAR_TEST";
-        private readonly IDictionary<string, string> _actualValuesDictionary = new Dictionary<string, string>()
+        private readonly IValueProvider _actualValuesDictionary = new DictionaryValueProvider(new Dictionary<string, string>()
         {
             [EV_TEST] = "ENV value"
-        };
+        });
 
         public ParserTests()
         {
-            Parsers.ActualValuesSnapshot = new ConcurrentDictionary<string, string>(_actualValuesDictionary);
+            Parsers.CurrentValueProvider = _actualValuesDictionary;
         }
 
         [Theory]
@@ -510,7 +510,7 @@ ENVVAR_TEST = ' yahooooo '
         [MemberData(nameof(ParseDotEnvTests))]
         public void ParseDotenvFileShouldParseContents(string _, string contents, KeyValuePair<string, string>[] expectedPairs)
         {
-            var outputs = Parsers.ParseDotenvFile(contents, actualValues: _actualValuesDictionary).ToArray();
+            var outputs = Parsers.ParseDotenvFile(contents, actualValueProvider: _actualValuesDictionary).ToArray();
             Assert.Equal(expectedPairs.Length, outputs.Length);
 
             foreach (var (output, expected) in outputs.Zip(expectedPairs))

--- a/test/DotNetEnv.Tests/ParserTests.cs
+++ b/test/DotNetEnv.Tests/ParserTests.cs
@@ -11,22 +11,17 @@ using Superpower.Parsers;
 
 namespace DotNetEnv.Tests
 {
-    public class ParserTests : IDisposable
+    public class ParserTests
     {
         private const string EV_TEST = "ENVVAR_TEST";
-
-        public ParserTests ()
+        private readonly IDictionary<string, string> _actualValuesDictionary = new Dictionary<string, string>()
         {
-            Parsers.EnvVarSnapshot = new ConcurrentDictionary<string, string>()
-            {
-                [EV_TEST] = "ENV value"
-            };
-            Environment.SetEnvironmentVariable("EV_TEST_EMPTY", "");
-        }
+            [EV_TEST] = "ENV value"
+        };
 
-        public void Dispose ()
+        public ParserTests()
         {
-            Parsers.EnvVarSnapshot.Clear();
+            Parsers.ActualValuesSnapshot = new ConcurrentDictionary<string, string>(_actualValuesDictionary);
         }
 
         [Theory]
@@ -514,7 +509,7 @@ ENVVAR_TEST = ' yahooooo '
         [MemberData(nameof(ParseDotEnvTests))]
         public void ParseDotenvFileShouldParseContents(string _, string contents, KeyValuePair<string, string>[] expectedPairs)
         {
-            var outputs = Parsers.ParseDotenvFile(contents).ToArray();
+            var outputs = Parsers.ParseDotenvFile(contents, actualValues: _actualValuesDictionary).ToArray();
             Assert.Equal(expectedPairs.Length, outputs.Length);
 
             foreach (var (output, expected) in outputs.Zip(expectedPairs))

--- a/test/DotNetEnv.Tests/ParserTests.cs
+++ b/test/DotNetEnv.Tests/ParserTests.cs
@@ -17,7 +17,7 @@ namespace DotNetEnv.Tests
 
         public ParserTests ()
         {
-            Env.EnvVarSnapshot = new ConcurrentDictionary<string, string>()
+            Parsers.EnvVarSnapshot = new ConcurrentDictionary<string, string>()
             {
                 [EV_TEST] = "ENV value"
             };
@@ -26,7 +26,7 @@ namespace DotNetEnv.Tests
 
         public void Dispose ()
         {
-            Env.EnvVarSnapshot.Clear();
+            Parsers.EnvVarSnapshot.Clear();
         }
 
         [Theory]

--- a/test/DotNetEnv.Tests/ParserTests.cs
+++ b/test/DotNetEnv.Tests/ParserTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Linq;
 using System.Collections.Generic;
 using DotNetEnv.Superpower;
@@ -13,30 +14,19 @@ namespace DotNetEnv.Tests
     public class ParserTests : IDisposable
     {
         private const string EV_TEST = "ENVVAR_TEST";
-        private const string EV_DNE = "EV_DNE";
-        private const string EV_TEST_1 = "EV_TEST_1";
-        private const string EV_TEST_2 = "EV_TEST_2";
-
-        private readonly Dictionary<string,string> oldEnvvars = new();
-        private static readonly string[] ALL_EVS = { EV_TEST, EV_DNE, EV_TEST_1, EV_TEST_2 };
 
         public ParserTests ()
         {
-            foreach (var ev in ALL_EVS)
+            Env.EnvVarSnapshot = new ConcurrentDictionary<string, string>()
             {
-                oldEnvvars[ev] = Environment.GetEnvironmentVariable(ev);
-            }
-
-            Environment.SetEnvironmentVariable(EV_TEST, "ENV value");
+                [EV_TEST] = "ENV value"
+            };
             Environment.SetEnvironmentVariable("EV_TEST_EMPTY", "");
         }
 
         public void Dispose ()
         {
-            foreach (var ev in ALL_EVS)
-            {
-                Environment.SetEnvironmentVariable(ev, oldEnvvars[ev]);
-            }
+            Env.EnvVarSnapshot.Clear();
         }
 
         [Theory]

--- a/test/DotNetEnv.Tests/ParserTests.cs
+++ b/test/DotNetEnv.Tests/ParserTests.cs
@@ -514,20 +514,17 @@ ENVVAR_TEST = ' yahooooo '
         [MemberData(nameof(ParseDotEnvTests))]
         public void ParseDotenvFileShouldParseContents(string _, string contents, KeyValuePair<string, string>[] expectedPairs)
         {
-            var outputs = Parsers.ParseDotenvFile(contents, Parsers.SetEnvVar).ToArray();
+            var outputs = Parsers.ParseDotenvFile(contents).ToArray();
             Assert.Equal(expectedPairs.Length, outputs.Length);
 
             foreach (var (output, expected) in outputs.Zip(expectedPairs))
-            {
                 Assert.Equal(expected, output);
-                Assert.Equal(expected.Value, Environment.GetEnvironmentVariable(output.Key));
-            }
         }
 
         [Theory]
         [InlineData("EV_DNE=0\n1")]
         public void ParseDotenvFileShouldThrowOnContents(string invalidContents) =>
-            Assert.Throws<ParseException>(() => Parsers.ParseDotenvFile(invalidContents, Parsers.SetEnvVar));
+            Assert.Throws<ParseException>(() => Parsers.ParseDotenvFile(invalidContents));
 
         // C# wow that you can't handle 32 bit unicode as chars. wow. strings for 4 byte chars.
     }


### PR DESCRIPTION
Solves #92

Decoupling the concerns of Parsers and Env leads to a more consistent behaviour with different LoadOptions.
Namely it solves the different behaviour of Interpolation, when setting SetEnvVars to true or false.

While the parsers main responsibility now is correct parsing and returning the values from the EnvFile, the Env-class takes the responsibility about setting EnvVars, preventing clobber and so on.

With a next step it would be additionally possible to add a LoadOptions-Parameter to be able to ignore (System-)Environment variables at all, which could be a good thing if you work on a system which is polluted with EnvVars by default, and you don't want to see any side effects from your systems EnvVars.