### PR TITLE
Fix/utf8 recognition

### DIFF
--- a/src/DotNetEnv/DotNetEnv.csproj
+++ b/src/DotNetEnv/DotNetEnv.csproj
@@ -15,6 +15,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/tonerdo/dotnet-env</RepositoryUrl>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DotNetEnv/DotNetEnv.csproj
+++ b/src/DotNetEnv/DotNetEnv.csproj
@@ -15,7 +15,6 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/tonerdo/dotnet-env</RepositoryUrl>
-    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DotNetEnv/Parsers.cs
+++ b/src/DotNetEnv/Parsers.cs
@@ -125,13 +125,25 @@ namespace DotNetEnv
             (from value in OctalByte.Repeat(1, 8)
             select ToUtf8Char(value)).Try();
 
-        // https://en.wikipedia.org/wiki/UTF-8#Description
         internal static readonly TextParser<string> Utf8Char =
-            (from value in HexByte.Repeat(1).Where(b => b[0] < '\x80')
-                    .Or(HexByte.Repeat(2).Where(bytes => bytes[0] < '\xE0'))
-                    .Or(HexByte.Repeat(3).Where(bytes => bytes[0] < '\xF0'))
-                    .Or(HexByte.Repeat(4))
-                select ToUtf8Char(value)).Try();
+            (from firstByte in HexByte
+                from nextBytes in HexByte.Repeat(GetUtf8CharByteCount(firstByte) - 1)
+                select ToUtf8Char(new[] { firstByte }.Concat(nextBytes))).Try();
+
+        /// <summary>
+        /// Returns byte-count of a UTF-8 character by its first byte.
+        /// </summary>
+        /// <param name="firstByte">The first byte of the UTF-8 char</param>
+        /// <returns>the byte-count of a UTF-8 char.</returns>
+        /// <remarks>https://en.wikipedia.org/wiki/UTF-8#Description</remarks>
+        private static int GetUtf8CharByteCount(byte firstByte)
+            => firstByte switch
+            {
+                < (byte)'\x80' => 1,
+                < (byte)'\xE0' => 2,
+                < (byte)'\xF0' => 3,
+                _ => 4,
+            };
 
         internal static readonly TextParser<string> Utf16Char =
             (from start in Span.EqualTo("\\u")

--- a/src/DotNetEnv/Parsers.cs
+++ b/src/DotNetEnv/Parsers.cs
@@ -125,9 +125,13 @@ namespace DotNetEnv
             (from value in OctalByte.Repeat(1, 8)
             select ToUtf8Char(value)).Try();
 
+        // https://en.wikipedia.org/wiki/UTF-8#Description
         internal static readonly TextParser<string> Utf8Char =
-            (from value in HexByte.Repeat(1, 4)
-            select ToUtf8Char(value)).Try();
+            (from value in HexByte.Repeat(1).Where(b => b[0] < '\x80')
+                    .Or(HexByte.Repeat(2).Where(bytes => bytes[0] < '\xE0'))
+                    .Or(HexByte.Repeat(3).Where(bytes => bytes[0] < '\xF0'))
+                    .Or(HexByte.Repeat(4))
+                select ToUtf8Char(value)).Try();
 
         internal static readonly TextParser<string> Utf16Char =
             (from start in Span.EqualTo("\\u")

--- a/src/DotNetEnv/Parsers.cs
+++ b/src/DotNetEnv/Parsers.cs
@@ -137,13 +137,10 @@ namespace DotNetEnv
         /// <returns>the byte-count of a UTF-8 char.</returns>
         /// <remarks>https://en.wikipedia.org/wiki/UTF-8#Description</remarks>
         private static int GetUtf8CharByteCount(byte firstByte)
-            => firstByte switch
-            {
-                < (byte)'\x80' => 1,
-                < (byte)'\xE0' => 2,
-                < (byte)'\xF0' => 3,
-                _ => 4,
-            };
+            => firstByte < (byte)'\x80' ? 1
+                : firstByte < (byte)'\xE0' ? 2
+                : firstByte < (byte)'\xF0' ? 3
+                : 4;
 
         internal static readonly TextParser<string> Utf16Char =
             (from start in Span.EqualTo("\\u")

--- a/test/DotNetEnv.Tests/ParserTests.cs
+++ b/test/DotNetEnv.Tests/ParserTests.cs
@@ -344,7 +344,7 @@ namespace DotNetEnv.Tests
 
             Assert.Equal(@"\xe6\x97\xa5\xe6\x9c\xac", Parsers.Value.AtEnd().Parse(@"\xe6\x97\xa5\xe6\x9c\xac").Value);
             Assert.Equal(@"\xe6\x97\xa5\xe6\x9c\xac", Parsers.Value.AtEnd().Parse(@"'\xe6\x97\xa5\xe6\x9c\xac'").Value);
-            Assert.Equal("日本", Parsers.Value.AtEnd().Parse(@"""\xe6\x97\xa5\xe6\x9c\xac""").Value);
+            Assert.Equal("日本", Parsers.Value.AtEnd().Parse("\"\\xe6\\x97\\xa5\\xe6\\x9c\\xac\"").Value);
 
             Assert.Throws<ParseException>(() => Parsers.Value.AtEnd().Parse("0\n1"));
             Assert.Throws<ParseException>(() => Parsers.Value.Parse(" "));

--- a/test/DotNetEnv.Tests/ParserTests.cs
+++ b/test/DotNetEnv.Tests/ParserTests.cs
@@ -238,8 +238,6 @@ namespace DotNetEnv.Tests
             Assert.Equal("a b c", Parsers.UnquotedValue.AtEnd().Parse("a b c").Value);
             Assert.Equal("041", Parsers.UnquotedValue.AtEnd().Parse("041").Value);
             Assert.Equal("日本", Parsers.UnquotedValue.AtEnd().Parse("日本").Value);
-            // TODO: is it possible to get the system to recognize when a complete unicode char is present and start the next one then, without a space?
-//            Assert.Equal("日本", Parsers.UnquotedValue.Parse(@"\xe6\x97\xa5\xe6\x9c\xac"));
 
             Assert.Throws<ParseException>(() => Parsers.UnquotedValue.AtEnd().Parse("0\n1"));
             Assert.Throws<ParseException>(() => Parsers.UnquotedValue.AtEnd().Parse("'"));
@@ -275,6 +273,11 @@ namespace DotNetEnv.Tests
             Assert.Equal("☠ ®", Parsers.DoubleQuotedValueContents.AtEnd().Parse(@"\xE2\x98\xA0 \uae").Value);
 
             Assert.Equal("日 ENV value 本", Parsers.DoubleQuotedValueContents.AtEnd().Parse("\\xe6\\x97\\xa5 $ENVVAR_TEST 本").Value);
+
+            Assert.Equal("日", Parsers.DoubleQuotedValueContents.AtEnd().Parse(@"\xe6\x97\xa5").Value);
+            Assert.Equal("本", Parsers.DoubleQuotedValueContents.AtEnd().Parse(@"\xe6\x9c\xac").Value);
+            Assert.Equal("日 本", Parsers.DoubleQuotedValueContents.AtEnd().Parse(@"\xe6\x97\xa5 \xe6\x9c\xac").Value);
+            Assert.Equal("日本", Parsers.DoubleQuotedValueContents.AtEnd().Parse(@"\xe6\x97\xa5\xe6\x9c\xac").Value);
 
             Assert.Equal("a\"b c", Parsers.DoubleQuotedValueContents.AtEnd().Parse("a\\\"b c").Value);
             Assert.Equal("a'b c", Parsers.DoubleQuotedValueContents.AtEnd().Parse("a'b c").Value);
@@ -338,8 +341,10 @@ namespace DotNetEnv.Tests
             Assert.Equal("a#b#c", Parsers.Value.AtEnd().Parse("a#b#c").Value);
             Assert.Equal("041", Parsers.Value.AtEnd().Parse("041").Value);
             Assert.Equal("日本", Parsers.Value.AtEnd().Parse("日本").Value);
-            // TODO: is it possible to get the system to recognize when a complete unicode char is present and start the next one then, without a space?
-//            Assert.Equal("日本", Parsers.Value.AtEnd().Parse(@"\xe6\x97\xa5\xe6\x9c\xac"));
+
+            Assert.Equal(@"\xe6\x97\xa5\xe6\x9c\xac", Parsers.Value.AtEnd().Parse(@"\xe6\x97\xa5\xe6\x9c\xac").Value);
+            Assert.Equal(@"\xe6\x97\xa5\xe6\x9c\xac", Parsers.Value.AtEnd().Parse(@"'\xe6\x97\xa5\xe6\x9c\xac'").Value);
+            Assert.Equal("日本", Parsers.Value.AtEnd().Parse(@"""\xe6\x97\xa5\xe6\x9c\xac""").Value);
 
             Assert.Throws<ParseException>(() => Parsers.Value.AtEnd().Parse("0\n1"));
             Assert.Throws<ParseException>(() => Parsers.Value.Parse(" "));


### PR DESCRIPTION
Worked on resolving the comment about problems with Utf8 recognition.

There are 2 commits, both work and solve the problem.
Personally I prefer the later one (current state of the branch), it moves the complexity of the Utf8 Byte count out of the parser itself.

The need for LangVersion 9 should be okay I guess, it allows the usage of the new `return x switch`-statement.