### PR TITLE
Refactor tests using Theory

### DIFF
--- a/test/DotNetEnv.Tests/ExtensionsTests.cs
+++ b/test/DotNetEnv.Tests/ExtensionsTests.cs
@@ -15,37 +15,40 @@ public class ExtensionsTests
     private static readonly KeyValuePair<string, string>[] KvpSetNoDupe = { FirstValuePair, SecondValuePair };
     private static readonly KeyValuePair<string, string>[] KvpSetWithDupe = { FirstValuePair, FirstValuePairDupe };
 
+    /// <summary>
+    /// Data: _, dictionaryOption, input, expectedValue
+    /// </summary>
     public static readonly TheoryData<
-            string, KeyValuePair<string, string>[], CreateDictionaryOption, KeyValuePair<string, string>[]>
+            string, CreateDictionaryOption, KeyValuePair<string, string>[], KeyValuePair<string, string>[]>
         ToDotEnvDictionaryTestData =
             new IndexedTheoryData<
-                KeyValuePair<string, string>[], CreateDictionaryOption, KeyValuePair<string, string>[]>
+                CreateDictionaryOption, KeyValuePair<string, string>[], KeyValuePair<string, string>[]>
             {
-                { KvpSetNoDupe, CreateDictionaryOption.Throw, KvpSetNoDupe },
-                { KvpSetWithDupe, CreateDictionaryOption.TakeFirst, new[] { FirstValuePair } },
-                { KvpSetNoDupe, CreateDictionaryOption.TakeFirst, KvpSetNoDupe },
-                { KvpSetWithDupe, CreateDictionaryOption.TakeLast, new[] { FirstValuePairDupe } },
-                { KvpSetNoDupe, CreateDictionaryOption.TakeLast, KvpSetNoDupe },
+                { CreateDictionaryOption.Throw, KvpSetNoDupe, KvpSetNoDupe },
+                { CreateDictionaryOption.TakeFirst, KvpSetWithDupe, new[] { FirstValuePair } },
+                { CreateDictionaryOption.TakeFirst, KvpSetNoDupe, KvpSetNoDupe },
+                { CreateDictionaryOption.TakeLast, KvpSetWithDupe, new[] { FirstValuePairDupe } },
+                { CreateDictionaryOption.TakeLast, KvpSetNoDupe, KvpSetNoDupe },
             };
 
     [Theory]
     [MemberData(nameof(ToDotEnvDictionaryTestData))]
     public void ToDotEnvDictionaryWithKvpSetNoDupeShouldContainValues(string _,
-        KeyValuePair<string, string>[] input,
         CreateDictionaryOption dictionaryOption,
-        KeyValuePair<string, string>[] expectedValues)
+        KeyValuePair<string, string>[] input,
+        KeyValuePair<string, string>[] expected)
     {
         var dotEnvDictionary = input.ToDotEnvDictionary(dictionaryOption);
 
-        foreach (var expectedValue in expectedValues)
-            Assert.Equal(expectedValue.Value, dotEnvDictionary[expectedValue.Key]);
+        foreach (var (key, value) in expected)
+            Assert.Equal(value, dotEnvDictionary[key]);
     }
 
     [Theory]
     [MemberData(nameof(ToDotEnvDictionaryTestData))]
     public void ToDotEnvDictionaryWithKvpSetNoDupeShouldHaveCorrectNumberOfEntries(string _,
-        KeyValuePair<string, string>[] input,
         CreateDictionaryOption dictionaryOption,
+        KeyValuePair<string, string>[] input,
         KeyValuePair<string, string>[] expectedValues)
     {
         var dotEnvDictionary = input.ToDotEnvDictionary(dictionaryOption);

--- a/test/DotNetEnv.Tests/ExtensionsTests.cs
+++ b/test/DotNetEnv.Tests/ExtensionsTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using DotNetEnv.Extensions;
 using DotNetEnv.Tests.XUnit;
 using Xunit;
@@ -16,17 +15,18 @@ public class ExtensionsTests
     private static readonly KeyValuePair<string, string>[] KvpSetNoDupe = { FirstValuePair, SecondValuePair };
     private static readonly KeyValuePair<string, string>[] KvpSetWithDupe = { FirstValuePair, FirstValuePairDupe };
 
-    public static readonly IndexedTheoryData<KeyValuePair<string, string>[],
-        CreateDictionaryOption,
-        KeyValuePair<string, string>[]> ToDotEnvDictionaryTestData =
-        new()
-        {
-            { KvpSetNoDupe, CreateDictionaryOption.Throw, KvpSetNoDupe },
-            { KvpSetWithDupe, CreateDictionaryOption.TakeFirst, new[] { FirstValuePair } },
-            { KvpSetNoDupe, CreateDictionaryOption.TakeFirst, KvpSetNoDupe },
-            { KvpSetWithDupe, CreateDictionaryOption.TakeLast, new[] { FirstValuePairDupe } },
-            { KvpSetNoDupe, CreateDictionaryOption.TakeLast, KvpSetNoDupe },
-        };
+    public static readonly TheoryData<
+            string, KeyValuePair<string, string>[], CreateDictionaryOption, KeyValuePair<string, string>[]>
+        ToDotEnvDictionaryTestData =
+            new IndexedTheoryData<
+                KeyValuePair<string, string>[], CreateDictionaryOption, KeyValuePair<string, string>[]>
+            {
+                { KvpSetNoDupe, CreateDictionaryOption.Throw, KvpSetNoDupe },
+                { KvpSetWithDupe, CreateDictionaryOption.TakeFirst, new[] { FirstValuePair } },
+                { KvpSetNoDupe, CreateDictionaryOption.TakeFirst, KvpSetNoDupe },
+                { KvpSetWithDupe, CreateDictionaryOption.TakeLast, new[] { FirstValuePairDupe } },
+                { KvpSetNoDupe, CreateDictionaryOption.TakeLast, KvpSetNoDupe },
+            };
 
     [Theory]
     [MemberData(nameof(ToDotEnvDictionaryTestData))]

--- a/test/DotNetEnv.Tests/FrameworkTests.cs
+++ b/test/DotNetEnv.Tests/FrameworkTests.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Text;
+using DotNetEnv.Tests.Helper;
+using Xunit;
+
+namespace DotNetEnv.Tests;
+
+public class FrameworkTests
+{
+    [Fact]
+    public void CheckUnicodeFunctionality()
+    {
+        Assert.Equal("®", Encoding.Unicode.GetString(new byte[] { 0xae, 0x00 }));
+        Assert.Equal(UnicodeChars.Rocket, Encoding.UTF32.GetString(new byte[] { 0x80, 0xf6, 0x01, 0x00 }));
+        Assert.Equal(UnicodeChars.Rocket, Encoding.UTF32.GetString(new byte[] { 0x80, 0xf6, 0x1, 0x0 }));
+    }
+
+    [Fact]
+    public void CheckEnvironmentVariableFunctionality()
+    {
+        Environment.SetEnvironmentVariable("EV_DNE", null);
+        Assert.Null(Environment.GetEnvironmentVariable("EV_DNE"));
+
+        // Note that dotnet returns null if the env var is empty -- even if it was set to empty!
+        Environment.SetEnvironmentVariable("EV_DNE", "");
+        Assert.Null(Environment.GetEnvironmentVariable("EV_DNE"));
+    }
+}

--- a/test/DotNetEnv.Tests/Helper/UnicodeChars.cs
+++ b/test/DotNetEnv.Tests/Helper/UnicodeChars.cs
@@ -1,0 +1,10 @@
+namespace DotNetEnv.Tests.Helper;
+
+public struct UnicodeChars
+{
+    // https://stackoverflow.com/questions/602912/how-do-you-echo-a-4-digit-unicode-character-in-bash
+    // printf '\xE2\x98\xA0'
+    // printf ☠ | hexdump  # hexdump has bytes flipped per word (2 bytes, 4 hex)
+
+    public const string Rocket = "\ud83d\ude80"; // 🚀
+}

--- a/test/DotNetEnv.Tests/LoadOptionsTests.cs
+++ b/test/DotNetEnv.Tests/LoadOptionsTests.cs
@@ -6,33 +6,33 @@ namespace DotNetEnv.Tests
 {
     public class LoadOptionsTests
     {
-        public static readonly TheoryData<string, LoadOptions,
-                (bool ExpectedSetEnvVars, bool ExpectedClobberExistingVars, bool ExpectedOnlyExactPath)>
-            LoadOptionTestCombinations = new IndexedTheoryData<LoadOptions, (bool ExpectedSetEnvVars, bool ExpectedClobberExistingVars, bool ExpectedOnlyExactPath)>()
+        /// <summary>
+        /// Data: _, optionsUnderTest, expectedSetEnvVars, expectedClobberExistingVars, expectedOnlyExactPath
+        /// </summary>
+        public static readonly TheoryData<string, LoadOptions, bool , bool, bool>
+            LoadOptionTestCombinations = new IndexedTheoryData<LoadOptions, bool, bool, bool>()
             {
-                { Env.NoEnvVars(), (false, true, true) },
-                { Env.NoClobber(), (true, false, true) },
-                { Env.TraversePath(), (true, true, false) },
-                { LoadOptions.NoEnvVars(), (false, true, true) },
-                { LoadOptions.NoClobber(), (true, false, true) },
-                { LoadOptions.TraversePath(), (true, true, false) },
-                { new LoadOptions(), (true, true, true) },
-                { new LoadOptions().NoEnvVars(), (false, true, true) },
-                { new LoadOptions().NoClobber(), (true, false, true) },
-                { new LoadOptions().TraversePath(), (true, true, false) },
-                { Env.NoEnvVars().NoClobber().TraversePath(), (false, false, false) },
-                { Env.NoClobber().TraversePath(), (true, false, false) },
-                { Env.NoEnvVars().NoClobber(), (false, false, true) },
-                { Env.NoEnvVars().TraversePath(), (false, true, false) },
+                { Env.NoEnvVars(), false, true, true },
+                { Env.NoClobber(), true, false, true },
+                { Env.TraversePath(), true, true, false },
+                { LoadOptions.NoEnvVars(), false, true, true },
+                { LoadOptions.NoClobber(), true, false, true },
+                { LoadOptions.TraversePath(), true, true, false },
+                { new LoadOptions(), true, true, true },
+                { new LoadOptions().NoEnvVars(), false, true, true },
+                { new LoadOptions().NoClobber(), true, false, true },
+                { new LoadOptions().TraversePath(), true, true, false },
+                { Env.NoEnvVars().NoClobber().TraversePath(), false, false, false },
+                { Env.NoClobber().TraversePath(), true, false, false },
+                { Env.NoEnvVars().NoClobber(), false, false, true },
+                { Env.NoEnvVars().TraversePath(), false, true, false },
             };
 
         [Theory]
         [MemberData(nameof(LoadOptionTestCombinations))]
         public void LoadOptionsShouldHaveCorrectPropertiesSet(string _, LoadOptions optionsUnderTest,
-            (bool ExpectedSetEnvVars, bool ExpectedClobberExistingVars, bool ExpectedOnlyExactPath) testData)
+            bool expectedSetEnvVars, bool expectedClobberExistingVars, bool expectedOnlyExactPath)
         {
-            var (expectedSetEnvVars, expectedClobberExistingVars, expectedOnlyExactPath) = testData;
-
             Assert.Equal(expectedSetEnvVars, optionsUnderTest.SetEnvVars);
             Assert.Equal(expectedClobberExistingVars, optionsUnderTest.ClobberExistingVars);
             Assert.Equal(expectedOnlyExactPath, optionsUnderTest.OnlyExactPath);

--- a/test/DotNetEnv.Tests/LoadOptionsTests.cs
+++ b/test/DotNetEnv.Tests/LoadOptionsTests.cs
@@ -5,40 +5,32 @@ namespace DotNetEnv.Tests
 {
     public class LoadOptionsTests
     {
-        public static readonly IndexedTheoryData<(LoadOptions OptionsUnderTest,
-                bool ExpectedSetEnvVars,
-                bool ExpectedClobberExistingVars,
-                bool ExpectedOnlyExactPath)>
-            LoadOptionTestCombinations = new ()
+        public static readonly IndexedTheoryData<LoadOptions,
+                (bool ExpectedSetEnvVars, bool ExpectedClobberExistingVars, bool ExpectedOnlyExactPath)>
+            LoadOptionTestCombinations = new()
             {
-                (Env.NoEnvVars(), false, true, true),
-                (Env.NoClobber(), true, false, true),
-                (Env.TraversePath(), true, true, false),
-                (LoadOptions.NoEnvVars(), false, true, true),
-                (LoadOptions.NoClobber(), true, false, true),
-                (LoadOptions.TraversePath(), true, true, false),
-                (new LoadOptions(), true, true, true),
-                (new LoadOptions().NoEnvVars(), false, true, true),
-                (new LoadOptions().NoClobber(), true, false, true),
-                (new LoadOptions().TraversePath(), true, true, false),
-                (Env.NoEnvVars().NoClobber().TraversePath(), false, false, false),
-                (Env.NoClobber().TraversePath(), true, false, false),
-                (Env.NoEnvVars().NoClobber(), false, false, true),
-                (Env.NoEnvVars().TraversePath(), false, true, false),
+                { Env.NoEnvVars(), (false, true, true) },
+                { Env.NoClobber(), (true, false, true) },
+                { Env.TraversePath(), (true, true, false) },
+                { LoadOptions.NoEnvVars(), (false, true, true) },
+                { LoadOptions.NoClobber(), (true, false, true) },
+                { LoadOptions.TraversePath(), (true, true, false) },
+                { new LoadOptions(), (true, true, true) },
+                { new LoadOptions().NoEnvVars(), (false, true, true) },
+                { new LoadOptions().NoClobber(), (true, false, true) },
+                { new LoadOptions().TraversePath(), (true, true, false) },
+                { Env.NoEnvVars().NoClobber().TraversePath(), (false, false, false) },
+                { Env.NoClobber().TraversePath(), (true, false, false) },
+                { Env.NoEnvVars().NoClobber(), (false, false, true) },
+                { Env.NoEnvVars().TraversePath(), (false, true, false) },
             };
 
         [Theory]
         [MemberData(nameof(LoadOptionTestCombinations))]
-        public void LoadOptionsShouldHaveCorrectPropertiesSet(string _,
-            (LoadOptions OptionsUnderTest,
-                bool ExpectedSetEnvVars,
-                bool ExpectedClobberExistingVars,
-                bool ExpectedOnlyExactPath) testData)
+        public void LoadOptionsShouldHaveCorrectPropertiesSet(string _, LoadOptions optionsUnderTest,
+            (bool ExpectedSetEnvVars, bool ExpectedClobberExistingVars, bool ExpectedOnlyExactPath) testData)
         {
-            var (optionsUnderTest,
-                    expectedSetEnvVars,
-                    expectedClobberExistingVars,
-                    expectedOnlyExactPath) = testData;
+            var (expectedSetEnvVars, expectedClobberExistingVars, expectedOnlyExactPath) = testData;
 
             Assert.Equal(expectedSetEnvVars, optionsUnderTest.SetEnvVars);
             Assert.Equal(expectedClobberExistingVars, optionsUnderTest.ClobberExistingVars);

--- a/test/DotNetEnv.Tests/LoadOptionsTests.cs
+++ b/test/DotNetEnv.Tests/LoadOptionsTests.cs
@@ -1,101 +1,48 @@
+using DotNetEnv.Tests.XUnit;
 using Xunit;
 
 namespace DotNetEnv.Tests
 {
     public class LoadOptionsTests
     {
-        [Fact]
-        public void StaticEnvTest()
+        public static readonly IndexedTheoryData<(LoadOptions OptionsUnderTest,
+                bool ExpectedSetEnvVars,
+                bool ExpectedClobberExistingVars,
+                bool ExpectedOnlyExactPath)>
+            LoadOptionTestCombinations = new ()
+            {
+                (Env.NoEnvVars(), false, true, true),
+                (Env.NoClobber(), true, false, true),
+                (Env.TraversePath(), true, true, false),
+                (LoadOptions.NoEnvVars(), false, true, true),
+                (LoadOptions.NoClobber(), true, false, true),
+                (LoadOptions.TraversePath(), true, true, false),
+                (new LoadOptions(), true, true, true),
+                (new LoadOptions().NoEnvVars(), false, true, true),
+                (new LoadOptions().NoClobber(), true, false, true),
+                (new LoadOptions().TraversePath(), true, true, false),
+                (Env.NoEnvVars().NoClobber().TraversePath(), false, false, false),
+                (Env.NoClobber().TraversePath(), true, false, false),
+                (Env.NoEnvVars().NoClobber(), false, false, true),
+                (Env.NoEnvVars().TraversePath(), false, true, false),
+            };
+
+        [Theory]
+        [MemberData(nameof(LoadOptionTestCombinations))]
+        public void LoadOptionsShouldHaveCorrectPropertiesSet(string _,
+            (LoadOptions OptionsUnderTest,
+                bool ExpectedSetEnvVars,
+                bool ExpectedClobberExistingVars,
+                bool ExpectedOnlyExactPath) testData)
         {
-            LoadOptions options;
+            var (optionsUnderTest,
+                    expectedSetEnvVars,
+                    expectedClobberExistingVars,
+                    expectedOnlyExactPath) = testData;
 
-            options = DotNetEnv.Env.NoEnvVars();
-            Assert.False(options.SetEnvVars);
-            Assert.True(options.ClobberExistingVars);
-            Assert.True(options.OnlyExactPath);
-
-            options = DotNetEnv.Env.NoClobber();
-            Assert.True(options.SetEnvVars);
-            Assert.False(options.ClobberExistingVars);
-            Assert.True(options.OnlyExactPath);
-
-            options = DotNetEnv.Env.TraversePath();
-            Assert.True(options.SetEnvVars);
-            Assert.True(options.ClobberExistingVars);
-            Assert.False(options.OnlyExactPath);
-        }
-
-        [Fact]
-        public void StaticOptionsTest()
-        {
-            LoadOptions options;
-
-            options = DotNetEnv.LoadOptions.NoEnvVars();
-            Assert.False(options.SetEnvVars);
-            Assert.True(options.ClobberExistingVars);
-            Assert.True(options.OnlyExactPath);
-
-            options = DotNetEnv.LoadOptions.NoClobber();
-            Assert.True(options.SetEnvVars);
-            Assert.False(options.ClobberExistingVars);
-            Assert.True(options.OnlyExactPath);
-
-            options = DotNetEnv.LoadOptions.TraversePath();
-            Assert.True(options.SetEnvVars);
-            Assert.True(options.ClobberExistingVars);
-            Assert.False(options.OnlyExactPath);
-        }
-
-        [Fact]
-        public void InstanceTest()
-        {
-            LoadOptions options;
-
-            options = new DotNetEnv.LoadOptions();
-            Assert.True(options.SetEnvVars);
-            Assert.True(options.ClobberExistingVars);
-            Assert.True(options.OnlyExactPath);
-
-            options = new DotNetEnv.LoadOptions().NoEnvVars();
-            Assert.False(options.SetEnvVars);
-            Assert.True(options.ClobberExistingVars);
-            Assert.True(options.OnlyExactPath);
-
-            options = new DotNetEnv.LoadOptions().NoClobber();
-            Assert.True(options.SetEnvVars);
-            Assert.False(options.ClobberExistingVars);
-            Assert.True(options.OnlyExactPath);
-
-            options = new DotNetEnv.LoadOptions().TraversePath();
-            Assert.True(options.SetEnvVars);
-            Assert.True(options.ClobberExistingVars);
-            Assert.False(options.OnlyExactPath);
-        }
-
-        [Fact]
-        public void ComboTest()
-        {
-            LoadOptions options;
-
-            options = DotNetEnv.Env.NoEnvVars().NoClobber().TraversePath();
-            Assert.False(options.SetEnvVars);
-            Assert.False(options.ClobberExistingVars);
-            Assert.False(options.OnlyExactPath);
-
-            options = DotNetEnv.Env.NoClobber().TraversePath();
-            Assert.True(options.SetEnvVars);
-            Assert.False(options.ClobberExistingVars);
-            Assert.False(options.OnlyExactPath);
-
-            options = DotNetEnv.Env.NoEnvVars().NoClobber();
-            Assert.False(options.SetEnvVars);
-            Assert.False(options.ClobberExistingVars);
-            Assert.True(options.OnlyExactPath);
-
-            options = DotNetEnv.Env.NoEnvVars().TraversePath();
-            Assert.False(options.SetEnvVars);
-            Assert.True(options.ClobberExistingVars);
-            Assert.False(options.OnlyExactPath);
+            Assert.Equal(expectedSetEnvVars, optionsUnderTest.SetEnvVars);
+            Assert.Equal(expectedClobberExistingVars, optionsUnderTest.ClobberExistingVars);
+            Assert.Equal(expectedOnlyExactPath, optionsUnderTest.OnlyExactPath);
         }
     }
 }

--- a/test/DotNetEnv.Tests/LoadOptionsTests.cs
+++ b/test/DotNetEnv.Tests/LoadOptionsTests.cs
@@ -1,3 +1,4 @@
+using System;
 using DotNetEnv.Tests.XUnit;
 using Xunit;
 
@@ -5,9 +6,9 @@ namespace DotNetEnv.Tests
 {
     public class LoadOptionsTests
     {
-        public static readonly IndexedTheoryData<LoadOptions,
+        public static readonly TheoryData<string, LoadOptions,
                 (bool ExpectedSetEnvVars, bool ExpectedClobberExistingVars, bool ExpectedOnlyExactPath)>
-            LoadOptionTestCombinations = new()
+            LoadOptionTestCombinations = new IndexedTheoryData<LoadOptions, (bool ExpectedSetEnvVars, bool ExpectedClobberExistingVars, bool ExpectedOnlyExactPath)>()
             {
                 { Env.NoEnvVars(), (false, true, true) },
                 { Env.NoClobber(), (true, false, true) },

--- a/test/DotNetEnv.Tests/ParserTests.cs
+++ b/test/DotNetEnv.Tests/ParserTests.cs
@@ -66,17 +66,14 @@ namespace DotNetEnv.Tests
         public void IdentifierShouldThrowOnParseUntilEnd(string invalidIdentifier) =>
             Assert.Throws<ParseException>(() => Parsers.Identifier.AtEnd().Parse(invalidIdentifier));
 
-        [Fact]
-        public void ParseOctalByte ()
-        {
-            Assert.Equal(33, Parsers.OctalByte.AtEnd().Parse(@"\41"));
-            Assert.Equal(33, Parsers.OctalByte.AtEnd().Parse(@"\041"));
-            Assert.Equal(90, Parsers.OctalByte.AtEnd().Parse(@"\132"));
+        [Theory]
+        [InlineData(33, @"\41")]
+        [InlineData(33, @"\041")]
+        [InlineData(90, @"\132")]
+        //[InlineData(???, @"\412")] // bash accepts values outside of ASCII range? check printf "\412"
+        public void OctalByteShouldParseUntilEnd(byte expected, string input) =>
+            Assert.Equal(expected, Parsers.OctalByte.AtEnd().Parse(input));
 
-            // NOTE that bash accepts values outside of ASCII range?
-            // printf "\412"
-            //Assert.Equal(???, Parsers.OctalChar.AtEnd().Parse(@"\412"));
-        }
 
         [Fact]
         public void ParseOctalChar ()

--- a/test/DotNetEnv.Tests/ParserTests.cs
+++ b/test/DotNetEnv.Tests/ParserTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using DotNetEnv.Tests.XUnit;
 using Xunit;
 using Superpower;
 
@@ -404,7 +405,7 @@ namespace DotNetEnv.Tests
         public void AssignmentShouldThrowOnParse(string invalidInput) =>
             Assert.Throws<ParseException>(() => Parsers.Assignment.Parse(invalidInput));
 
-        public static readonly TheoryData<(string Contents, KeyValuePair<string, string>[] Expecteds)>
+        public static readonly IndexedTheoryData<(string Contents, KeyValuePair<string, string>[] Expecteds)>
             ParseDotEnvTests = new()
             {
                 ("", Array.Empty<KeyValuePair<string, string>>()),
@@ -446,7 +447,7 @@ ENVVAR_TEST = ' yahooooo '
             };
         [Theory]
         [MemberData(nameof(ParseDotEnvTests))]
-        public void ParseDotenvFileShouldParseContents((string Contents, KeyValuePair<string, string>[] Expecteds) testData)
+        public void ParseDotenvFileShouldParseContents(string _, (string Contents, KeyValuePair<string, string>[] Expecteds) testData)
         {
             var (contents, expectedPairs) = testData;
 

--- a/test/DotNetEnv.Tests/ParserTests.cs
+++ b/test/DotNetEnv.Tests/ParserTests.cs
@@ -131,12 +131,12 @@ namespace DotNetEnv.Tests
         public void InterpolatedBracesEnvVarShouldParseUntilEnd(string expected, string input) =>
             Assert.Equal(expected, Parsers.InterpolatedBracesEnvVar.AtEnd().Parse(input).GetValue());
 
-        public void ParseInterpolated ()
-        {
-            Assert.Equal("ENV value", Parsers.InterpolatedValue.AtEnd().Parse("$ENVVAR_TEST").GetValue());
-            Assert.Equal("ENV value", Parsers.InterpolatedValue.AtEnd().Parse("${ENVVAR_TEST}").GetValue());
-            Assert.Equal("", Parsers.InterpolatedValue.AtEnd().Parse("${ENVVAR_TEST_DNE}").GetValue());
-        }
+        [Theory]
+        [InlineData("ENV value", "$ENVVAR_TEST")]
+        [InlineData("ENV value", "${ENVVAR_TEST}")]
+        [InlineData("", "${ENVVAR_TEST_DNE}")]
+        public void InterpolatedValueShouldParseUntilEnd(string expected, string input) =>
+            Assert.Equal(expected, Parsers.InterpolatedValue.AtEnd().Parse(input).GetValue());
 
         [Fact]
         public void ParseNotControlNorWhitespace ()

--- a/test/DotNetEnv.Tests/ParserTests.cs
+++ b/test/DotNetEnv.Tests/ParserTests.cs
@@ -98,14 +98,12 @@ namespace DotNetEnv.Tests
         public void Utf8CharShouldParseUntilEnd(string expected, string input) =>
             Assert.Equal(expected, Parsers.Utf8Char.AtEnd().Parse(input));
 
-        [Fact]
-        public void ParseUtf16Char ()
-        {
-            Assert.Equal("®", Parsers.Utf16Char.AtEnd().Parse(@"\u00ae"));
-            Assert.Equal("®", Parsers.Utf16Char.AtEnd().Parse(@"\uae"));
+        [Theory]
+        [InlineData("®", @"\u00ae")]
+        [InlineData("®", @"\uae")]
+        public void Utf16CharShouldParseUntilEnd(string expected, string input) =>
+            Assert.Equal(expected, Parsers.Utf16Char.AtEnd().Parse(input));
 
-            Assert.Equal("®", Encoding.Unicode.GetString(new byte[] { 0xae, 0x00 }));
-        }
 
         [Fact]
         public void ParseUtf32Char ()

--- a/test/DotNetEnv.Tests/ParserTests.cs
+++ b/test/DotNetEnv.Tests/ParserTests.cs
@@ -278,17 +278,15 @@ namespace DotNetEnv.Tests
         public void SingleQuotedValueShouldThrowOnParseUntilEnd(string invalidInput) =>
             Assert.Throws<ParseException>(() => Parsers.SingleQuotedValue.AtEnd().Parse(invalidInput).Value);
 
-        [Fact]
-        public void ParseDoubleQuotedValue ()
-        {
-            Assert.Equal("abc", Parsers.DoubleQuotedValue.AtEnd().Parse("\"abc\"").Value);
-            Assert.Equal("a b c", Parsers.DoubleQuotedValue.AtEnd().Parse("\"a b c\"").Value);
-            Assert.Equal("0\n1", Parsers.DoubleQuotedValue.AtEnd().Parse("\"0\n1\"").Value);
-            Assert.Equal("a'bc", Parsers.DoubleQuotedValue.AtEnd().Parse("\"a'bc\"").Value);
-            Assert.Equal("a\"bc", Parsers.DoubleQuotedValue.AtEnd().Parse("\"a\\\"bc\"").Value);
-
-            Assert.Equal("日 ENV value 本", Parsers.DoubleQuotedValue.AtEnd().Parse("\"\\xe6\\x97\\xa5 $ENVVAR_TEST 本\"").Value);
-        }
+        [Theory]
+        [InlineData("abc", "\"abc\"")]
+        [InlineData("a b c", "\"a b c\"")]
+        [InlineData("0\n1", "\"0\n1\"")]
+        [InlineData("a'bc", "\"a'bc\"")]
+        [InlineData("a\"bc", "\"a\\\"bc\"")]
+        [InlineData("日 ENV value 本", "\"\\xe6\\x97\\xa5 $ENVVAR_TEST 本\"")]
+        public void DoubleQuotedValueShouldParseUntilEnd(string expected, string input) =>
+            Assert.Equal(expected, Parsers.DoubleQuotedValue.AtEnd().Parse(input).Value);
 
         [Fact]
         public void TestExportExpression()

--- a/test/DotNetEnv.Tests/ParserTests.cs
+++ b/test/DotNetEnv.Tests/ParserTests.cs
@@ -74,18 +74,15 @@ namespace DotNetEnv.Tests
         public void OctalByteShouldParseUntilEnd(byte expected, string input) =>
             Assert.Equal(expected, Parsers.OctalByte.AtEnd().Parse(input));
 
+        [Theory]
+        [InlineData("!", @"\41")]
+        [InlineData("!", @"\041")]
+        [InlineData("Z", @"\132")]
+        //[InlineData(???, @"\412")] // as above with ShouldParseOctalByte() for values outside of ASCII range
+        // TODO: tests for octal combinations to utf8?
+        public void OctalCharShouldParseUntilEnd(string expected, string input) =>
+            Assert.Equal(expected, Parsers.OctalChar.AtEnd().Parse(input));
 
-        [Fact]
-        public void ParseOctalChar ()
-        {
-            Assert.Equal("!", Parsers.OctalChar.AtEnd().Parse(@"\41"));
-            Assert.Equal("!", Parsers.OctalChar.AtEnd().Parse(@"\041"));
-            Assert.Equal("Z", Parsers.OctalChar.AtEnd().Parse(@"\132"));
-
-            // as above for values outside of ASCII range
-
-            // TODO: tests for octal combinations to utf8?
-        }
 
         [Fact]
         public void ParseHexByte ()

--- a/test/DotNetEnv.Tests/ParserTests.cs
+++ b/test/DotNetEnv.Tests/ParserTests.cs
@@ -192,24 +192,27 @@ namespace DotNetEnv.Tests
         public void CommentShouldParseUntilEnd(string expected, string input) =>
             Assert.Equal(expected, Parsers.Comment.AtEnd().Parse(input));
 
-        [Fact]
-        public void ParseEmpty ()
+        [Theory]
+        [InlineData("# comment 1")]
+        [InlineData("# comment 2\r\n")]
+        [InlineData("# comment 3\n")]
+        [InlineData("\r\n")]
+        [InlineData("\n")]
+        [InlineData("   # comment 1")]
+        [InlineData("    \r\n")]
+        [InlineData("#export EV_DNE=\"\\xe6\\x97\\xa5 $ENVVAR_TEST 本\"#ccccc\n")]
+        public void EmptyShouldParseUntilEnd(string input)
         {
-            var kvp = new KeyValuePair<string, string>(null, null);
+            var expected = new KeyValuePair<string, string>(null, null);
 
-            Assert.Throws<ParseException>(() => Parsers.Empty.AtEnd().Parse(""));
-
-            Assert.Equal(kvp, Parsers.Empty.AtEnd().Parse("# comment 1"));
-            Assert.Equal(kvp, Parsers.Empty.AtEnd().Parse("# comment 2\r\n"));
-            Assert.Equal(kvp, Parsers.Empty.AtEnd().Parse("# comment 3\n"));
-
-            Assert.Equal(kvp, Parsers.Empty.AtEnd().Parse("\r\n"));
-            Assert.Equal(kvp, Parsers.Empty.AtEnd().Parse("\n"));
-
-            Assert.Equal(kvp, Parsers.Empty.AtEnd().Parse("   # comment 1"));
-            Assert.Equal(kvp, Parsers.Empty.AtEnd().Parse("    \r\n"));
-            Assert.Equal(kvp, Parsers.Empty.AtEnd().Parse("#export EV_DNE=\"\\xe6\\x97\\xa5 $ENVVAR_TEST 本\"#ccccc\n"));
+            Assert.Equal(expected, Parsers.Empty.AtEnd().Parse(input));
         }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("that's not empty")]
+        public void EmptyShouldThrowOnParseUntilEnd(string input) =>
+            Assert.Throws<ParseException>(() => Parsers.Empty.AtEnd().Parse(input));
 
         [Fact]
         public void ParseUnquotedValue ()

--- a/test/DotNetEnv.Tests/ParserTests.cs
+++ b/test/DotNetEnv.Tests/ParserTests.cs
@@ -110,14 +110,16 @@ namespace DotNetEnv.Tests
         public void Utf32CharShouldParseUntilEnd(string expected, string input) =>
             Assert.Equal(expected, Parsers.Utf32Char.AtEnd().Parse(input));
 
-        [Fact]
-        public void ParseEscapedChar ()
-        {
-            Assert.Equal("\b", Parsers.EscapedChar.AtEnd().Parse("\\b"));
-            Assert.Equal("'", Parsers.EscapedChar.AtEnd().Parse("\\'"));
-            Assert.Equal("\"", Parsers.EscapedChar.AtEnd().Parse("\\\""));
-            Assert.Throws<ParseException>(() => Parsers.EscapedChar.AtEnd().Parse("\n"));
-        }
+        [InlineData("\b", "\\b")]
+        [InlineData("'", "\\'")]
+        [InlineData("\"", "\\\"")]
+        public void EscapedCharShouldParseUntilEnd(string expected, string input) =>
+            Assert.Equal(expected, Parsers.EscapedChar.AtEnd().Parse(input));
+
+        [Theory]
+        [InlineData("\n")]
+        public void EscapedCharShouldThrowOnParseUntilEnd(string invalidInput) =>
+            Assert.Throws<ParseException>(() => Parsers.EscapedChar.AtEnd().Parse(invalidInput));
 
         [Fact]
         public void ParseInterpolatedEnvVar ()

--- a/test/DotNetEnv.Tests/ParserTests.cs
+++ b/test/DotNetEnv.Tests/ParserTests.cs
@@ -246,25 +246,20 @@ namespace DotNetEnv.Tests
         public void UnquotedValueShouldThrowOnParseUntilEnd(string invalidInput) =>
             Assert.Throws<ParseException>(() => Parsers.UnquotedValue.AtEnd().Parse(invalidInput));
 
-        [Fact]
-        public void ParseDoubleQuotedValueContents ()
-        {
-            Assert.Equal("abc", Parsers.DoubleQuotedValueContents.AtEnd().Parse("abc").Value);
-            Assert.Equal("a b c", Parsers.DoubleQuotedValueContents.AtEnd().Parse("a b c").Value);
-            Assert.Equal("0\n1", Parsers.DoubleQuotedValueContents.AtEnd().Parse("0\n1").Value);
-            Assert.Equal("日 本", Parsers.DoubleQuotedValueContents.AtEnd().Parse(@"\xe6\x97\xa5 \xe6\x9c\xac").Value);
-            Assert.Equal("☠ ®", Parsers.DoubleQuotedValueContents.AtEnd().Parse(@"\xE2\x98\xA0 \uae").Value);
-
-            Assert.Equal("日 ENV value 本", Parsers.DoubleQuotedValueContents.AtEnd().Parse("\\xe6\\x97\\xa5 $ENVVAR_TEST 本").Value);
-
-            Assert.Equal("日", Parsers.DoubleQuotedValueContents.AtEnd().Parse(@"\xe6\x97\xa5").Value);
-            Assert.Equal("本", Parsers.DoubleQuotedValueContents.AtEnd().Parse(@"\xe6\x9c\xac").Value);
-            Assert.Equal("日 本", Parsers.DoubleQuotedValueContents.AtEnd().Parse(@"\xe6\x97\xa5 \xe6\x9c\xac").Value);
-            Assert.Equal("日本", Parsers.DoubleQuotedValueContents.AtEnd().Parse(@"\xe6\x97\xa5\xe6\x9c\xac").Value);
-
-            Assert.Equal("a\"b c", Parsers.DoubleQuotedValueContents.AtEnd().Parse("a\\\"b c").Value);
-            Assert.Equal("a'b c", Parsers.DoubleQuotedValueContents.AtEnd().Parse("a'b c").Value);
-        }
+        [Theory]
+        [InlineData("abc", "abc")]
+        [InlineData("a b c", "a b c")]
+        [InlineData("0\n1", "0\n1")]
+        [InlineData("日", @"\xe6\x97\xa5")]
+        [InlineData("本", @"\xe6\x9c\xac")]
+        [InlineData("日 本", @"\xe6\x97\xa5 \xe6\x9c\xac")]
+        [InlineData("日本", @"\xe6\x97\xa5\xe6\x9c\xac")]
+        [InlineData("☠ ®", @"\xE2\x98\xA0 \uae")]
+        [InlineData("日 ENV value 本", @"\xe6\x97\xa5 $ENVVAR_TEST 本")]
+        [InlineData("a\"b c", "a\\\"b c")]
+        [InlineData("a'b c", "a'b c")]
+        public void DoubleQuotedValueContentsShouldParseUntilEnd(string expected, string input) =>
+            Assert.Equal(expected, Parsers.DoubleQuotedValueContents.AtEnd().Parse(input).Value);
 
         [Fact]
         public void ParseSingleQuotedValueContents ()

--- a/test/DotNetEnv.Tests/ParserTests.cs
+++ b/test/DotNetEnv.Tests/ParserTests.cs
@@ -83,12 +83,10 @@ namespace DotNetEnv.Tests
         public void OctalCharShouldParseUntilEnd(string expected, string input) =>
             Assert.Equal(expected, Parsers.OctalChar.AtEnd().Parse(input));
 
-
-        [Fact]
-        public void ParseHexByte ()
-        {
-            Assert.Equal(90, Parsers.HexByte.AtEnd().Parse(@"\x5a"));
-        }
+        [Theory]
+        [InlineData(90, @"\x5a")]
+        public void HexByteShouldParseUntilEnd(byte expected, string input) =>
+            Assert.Equal(expected, Parsers.HexByte.AtEnd().Parse(input));
 
         [Fact]
         public void ParseUtf8Char ()

--- a/test/DotNetEnv.Tests/ParserTests.cs
+++ b/test/DotNetEnv.Tests/ParserTests.cs
@@ -185,13 +185,12 @@ namespace DotNetEnv.Tests
         public void SpecialCharShouldThrowOnParseUntilEnd(string invalidInput) =>
             Assert.Throws<ParseException>(() => Parsers.SpecialChar.AtEnd().Parse(invalidInput));
 
-        [Fact]
-        public void ParseComment ()
-        {
-            Assert.Equal(" comment 1", Parsers.Comment.AtEnd().Parse("# comment 1"));
-            Assert.Equal("", Parsers.Comment.AtEnd().Parse("#"));
-            Assert.Equal(" ", Parsers.Comment.AtEnd().Parse("# "));
-        }
+        [Theory]
+        [InlineData(" comment 1", "# comment 1")]
+        [InlineData("", "#")]
+        [InlineData(" ", "# ")]
+        public void CommentShouldParseUntilEnd(string expected, string input) =>
+            Assert.Equal(expected, Parsers.Comment.AtEnd().Parse(input));
 
         [Fact]
         public void ParseEmpty ()

--- a/test/DotNetEnv.Tests/ParserTests.cs
+++ b/test/DotNetEnv.Tests/ParserTests.cs
@@ -288,15 +288,18 @@ namespace DotNetEnv.Tests
         public void DoubleQuotedValueShouldParseUntilEnd(string expected, string input) =>
             Assert.Equal(expected, Parsers.DoubleQuotedValue.AtEnd().Parse(input).Value);
 
-        [Fact]
-        public void TestExportExpression()
-        {
-            Assert.Throws<ParseException>(() => Parsers.ExportExpression.AtEnd().Parse("identifier "));
-            Assert.Equal("export", Parsers.ExportExpression.AtEnd().Parse("export "));
-            Assert.Equal("set -x", Parsers.ExportExpression.AtEnd().Parse("set -x "));
-            Assert.Equal("set", Parsers.ExportExpression.AtEnd().Parse("set "));
-            Assert.Equal("SET", Parsers.ExportExpression.AtEnd().Parse("SET "));
-        }
+        [Theory]
+        [InlineData("export", "export ")]
+        [InlineData("set -x", "set -x ")]
+        [InlineData("set", "set ")]
+        [InlineData("SET", "SET ")]
+        public void TestExportExpression(string expected, string input) => 
+            Assert.Equal(expected, Parsers.ExportExpression.AtEnd().Parse(input));
+
+        [Theory]
+        [InlineData("identifier ")]
+        public void ExportExpressionShouldThrowOnParseUntilEnd(string invalidInput) =>
+            Assert.Throws<ParseException>(() => Parsers.ExportExpression.AtEnd().Parse(invalidInput));
 
         [Fact]
         public void ParseValue ()

--- a/test/DotNetEnv.Tests/ParserTests.cs
+++ b/test/DotNetEnv.Tests/ParserTests.cs
@@ -1,21 +1,13 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-using System.Text;
-using DotNetEnv.Superpower;
 using Xunit;
 using Superpower;
-using Superpower.Parsers;
 
 namespace DotNetEnv.Tests
 {
     public class ParserTests : IDisposable
     {
-        // C# wow that you can't handle 32 bit unicode as chars. wow. strings for 4 byte chars.
-        private static readonly string RocketChar = char.ConvertFromUtf32(0x1F680); // 🚀
-
-        private const string EXCEPT_CHARS = "'\"$";
-
         private const string EV_TEST = "ENVVAR_TEST";
         private const string EV_DNE = "EV_DNE";
         private const string EV_TEST_1 = "EV_TEST_1";

--- a/test/DotNetEnv.Tests/ParserTests.cs
+++ b/test/DotNetEnv.Tests/ParserTests.cs
@@ -104,16 +104,11 @@ namespace DotNetEnv.Tests
         public void Utf16CharShouldParseUntilEnd(string expected, string input) =>
             Assert.Equal(expected, Parsers.Utf16Char.AtEnd().Parse(input));
 
-
-        [Fact]
-        public void ParseUtf32Char ()
-        {
-            Assert.Equal(RocketChar, Parsers.Utf32Char.AtEnd().Parse(@"\U0001F680"));
-            Assert.Equal(RocketChar, Parsers.Utf32Char.AtEnd().Parse(@"\U1F680"));
-
-            Assert.Equal(RocketChar, Encoding.UTF32.GetString(new byte[] { 0x80, 0xf6, 0x01, 0x00 }));
-            Assert.Equal(RocketChar, Encoding.UTF32.GetString(new byte[] { 0x80, 0xf6, 0x1, 0x0 }));
-        }
+        [Theory]
+        [InlineData(UnicodeChars.Rocket, @"\U0001F680")]
+        [InlineData(UnicodeChars.Rocket, @"\U1F680")]
+        public void Utf32CharShouldParseUntilEnd(string expected, string input) =>
+            Assert.Equal(expected, Parsers.Utf32Char.AtEnd().Parse(input));
 
         [Fact]
         public void ParseEscapedChar ()

--- a/test/DotNetEnv.Tests/ParserTests.cs
+++ b/test/DotNetEnv.Tests/ParserTests.cs
@@ -261,19 +261,16 @@ namespace DotNetEnv.Tests
         public void DoubleQuotedValueContentsShouldParseUntilEnd(string expected, string input) =>
             Assert.Equal(expected, Parsers.DoubleQuotedValueContents.AtEnd().Parse(input).Value);
 
-        [Fact]
-        public void ParseSingleQuotedValueContents ()
-        {
-            Assert.Equal("abc", Parsers.SingleQuotedValueContents.AtEnd().Parse("abc").Value);
-            Assert.Equal("a b c", Parsers.SingleQuotedValueContents.AtEnd().Parse("a b c").Value);
-            Assert.Equal("0\n1", Parsers.SingleQuotedValueContents.AtEnd().Parse("0\n1").Value);
-            Assert.Equal(@"\xe6\x97\xa5 \xe6\x9c\xac", Parsers.SingleQuotedValueContents.AtEnd().Parse(@"\xe6\x97\xa5 \xe6\x9c\xac").Value);
-            Assert.Equal(@"\xE2\x98\xA0 \uae", Parsers.SingleQuotedValueContents.AtEnd().Parse(@"\xE2\x98\xA0 \uae").Value);
-
-            Assert.Equal("\\xe6\\x97\\xa5 $ENVVAR_TEST 本", Parsers.SingleQuotedValueContents.AtEnd().Parse("\\xe6\\x97\\xa5 $ENVVAR_TEST 本").Value);
-
-            Assert.Equal("a\"b c", Parsers.SingleQuotedValueContents.AtEnd().Parse("a\"b c").Value);
-        }
+        [Theory]
+        [InlineData("abc", "abc")]
+        [InlineData("a b c", "a b c")]
+        [InlineData("0\n1", "0\n1")]
+        [InlineData(@"\xe6\x97\xa5 \xe6\x9c\xac", @"\xe6\x97\xa5 \xe6\x9c\xac")]
+        [InlineData(@"\xE2\x98\xA0 \uae", @"\xE2\x98\xA0 \uae")]
+        [InlineData(@"\xe6\x97\xa5 $ENVVAR_TEST 本", @"\xe6\x97\xa5 $ENVVAR_TEST 本")]
+        [InlineData("a\"b c", "a\"b c")]
+        public void SingleQuotedValueContentsShouldParseUntilEnd(string expected, string input) =>
+            Assert.Equal(expected, Parsers.SingleQuotedValueContents.AtEnd().Parse(input).Value);
 
         [Fact]
         public void ParseSingleQuotedValue ()

--- a/test/DotNetEnv.Tests/ParserTests.cs
+++ b/test/DotNetEnv.Tests/ParserTests.cs
@@ -42,26 +42,29 @@ namespace DotNetEnv.Tests
             }
         }
 
-        [Fact]
-        public void ParseIdentifier ()
-        {
-            Assert.Equal("name", Parsers.Identifier.AtEnd().Parse("name"));
-            Assert.Equal("_n", Parsers.Identifier.AtEnd().Parse("_n"));
-            Assert.Equal("__", Parsers.Identifier.AtEnd().Parse("__"));
-            Assert.Equal("_0", Parsers.Identifier.AtEnd().Parse("_0"));
-            Assert.Equal("a_b", Parsers.Identifier.AtEnd().Parse("a_b"));
-            Assert.Equal("_a_b", Parsers.Identifier.AtEnd().Parse("_a_b"));
-            Assert.Equal("a.b", Parsers.Identifier.AtEnd().Parse("a.b"));
-            Assert.Equal("a-b", Parsers.Identifier.AtEnd().Parse("a-b"));
-            Assert.Throws<ParseException>(() => Parsers.Identifier.AtEnd().Parse("\"name"));
-            Assert.Throws<ParseException>(() => Parsers.Identifier.AtEnd().Parse("0name"));
-            Assert.Throws<ParseException>(() => Parsers.Identifier.AtEnd().Parse(".a.b"));
-            Assert.Throws<ParseException>(() => Parsers.Identifier.AtEnd().Parse("-a.b"));
-            Assert.Throws<ParseException>(() => Parsers.Identifier.AtEnd().Parse("a!b"));
-            Assert.Throws<ParseException>(() => Parsers.Identifier.AtEnd().Parse("a?b"));
-            Assert.Throws<ParseException>(() => Parsers.Identifier.AtEnd().Parse("a*b"));
-            Assert.Throws<ParseException>(() => Parsers.Identifier.AtEnd().Parse("a:b"));
-        }
+        [Theory]
+        [InlineData("name")]
+        [InlineData("_n")]
+        [InlineData("__")]
+        [InlineData("_0")]
+        [InlineData("a_b")]
+        [InlineData("_a_b")]
+        [InlineData("a.b")]
+        [InlineData("a-b")]
+        public void IdentifierShouldParseUntilEnd(string identifier) =>
+            Assert.Equal(identifier, Parsers.Identifier.AtEnd().Parse(identifier));
+
+        [Theory]
+        [InlineData("\"name")]
+        [InlineData("0name")]
+        [InlineData(".a.b")]
+        [InlineData("-a.b")]
+        [InlineData("a!b")]
+        [InlineData("a?b")]
+        [InlineData("a*b")]
+        [InlineData("a:b")]
+        public void IdentifierShouldThrowOnParseUntilEnd(string invalidIdentifier) =>
+            Assert.Throws<ParseException>(() => Parsers.Identifier.AtEnd().Parse(invalidIdentifier));
 
         [Fact]
         public void ParseOctalByte ()

--- a/test/DotNetEnv.Tests/ParserTests.cs
+++ b/test/DotNetEnv.Tests/ParserTests.cs
@@ -405,6 +405,9 @@ namespace DotNetEnv.Tests
         public void AssignmentShouldThrowOnParse(string invalidInput) =>
             Assert.Throws<ParseException>(() => Parsers.Assignment.Parse(invalidInput));
 
+        /// <summary>
+        /// Data: _, contents, expectedPairs
+        /// </summary>
         public static readonly TheoryData<string, string, KeyValuePair<string, string>[]> ParseDotEnvTests =
             new IndexedTheoryData<string, KeyValuePair<string, string>[]>()
             {

--- a/test/DotNetEnv.Tests/ParserTests.cs
+++ b/test/DotNetEnv.Tests/ParserTests.cs
@@ -138,17 +138,26 @@ namespace DotNetEnv.Tests
         public void InterpolatedValueShouldParseUntilEnd(string expected, string input) =>
             Assert.Equal(expected, Parsers.InterpolatedValue.AtEnd().Parse(input).GetValue());
 
-        [Fact]
-        public void ParseNotControlNorWhitespace ()
-        {
-            Assert.Equal("a", Parsers.NotControlNorWhitespace(EXCEPT_CHARS).AtEnd().Parse("a"));
-            Assert.Equal("%", Parsers.NotControlNorWhitespace(EXCEPT_CHARS).AtEnd().Parse("%"));
-            Assert.Throws<ParseException>(() => Parsers.NotControlNorWhitespace(EXCEPT_CHARS).AtEnd().Parse(" "));
-            Assert.Throws<ParseException>(() => Parsers.NotControlNorWhitespace(EXCEPT_CHARS).AtEnd().Parse("\n"));
-            Assert.Throws<ParseException>(() => Parsers.NotControlNorWhitespace(EXCEPT_CHARS).AtEnd().Parse("'"));
-            Assert.Throws<ParseException>(() => Parsers.NotControlNorWhitespace(EXCEPT_CHARS).AtEnd().Parse("\""));
-            Assert.Throws<ParseException>(() => Parsers.NotControlNorWhitespace(EXCEPT_CHARS).AtEnd().Parse("$"));
-        }
+        [Theory]
+        [InlineData("a", "a", "")]
+        [InlineData("%", "%", "")]
+        [InlineData("\"", "\"", "1")]
+        [InlineData("$","$", "1")]
+        [InlineData("a","a", "1")]
+        public void NotControlNorWhitespaceShouldParseUntilEnd(string expected, string input, string excludedChars) =>
+            Assert.Equal(expected, Parsers.NotControlNorWhitespace(excludedChars).AtEnd().Parse(input));
+
+        [Theory]
+        [InlineData(" ", "")]
+        [InlineData(" ", "1234")]
+        [InlineData("\n", "")]
+        [InlineData("'", "'")]
+        [InlineData("\"", "\"")]
+        [InlineData("$", "$")]
+        [InlineData("a", "a")]
+        public void NotControlNorWhitespaceShouldThrowOnParseUntilEnd(string invalidInput, string excludedChars) =>
+            Assert.Throws<ParseException>(() =>
+                Parsers.NotControlNorWhitespace(excludedChars).AtEnd().Parse(invalidInput));
 
         [Fact]
         public void ParseSpecialChar ()

--- a/test/DotNetEnv.Tests/ParserTests.cs
+++ b/test/DotNetEnv.Tests/ParserTests.cs
@@ -272,18 +272,19 @@ namespace DotNetEnv.Tests
         public void SingleQuotedValueContentsShouldParseUntilEnd(string expected, string input) =>
             Assert.Equal(expected, Parsers.SingleQuotedValueContents.AtEnd().Parse(input).Value);
 
-        [Fact]
-        public void ParseSingleQuotedValue ()
-        {
-            Assert.Equal("abc", Parsers.SingleQuotedValue.AtEnd().Parse("'abc'").Value);
-            Assert.Equal("a b c", Parsers.SingleQuotedValue.AtEnd().Parse("'a b c'").Value);
-            Assert.Equal("0\n1", Parsers.SingleQuotedValue.AtEnd().Parse("'0\n1'").Value);
-            Assert.Equal("a\"bc", Parsers.SingleQuotedValue.AtEnd().Parse("'a\"bc'").Value);
+        [Theory]
+        [InlineData("abc", "'abc'")]
+        [InlineData("a b c", "'a b c'")]
+        [InlineData("0\n1", "'0\n1'")]
+        [InlineData("a\"bc", "'a\"bc'")]
+        [InlineData(@"\xe6\x97\xa5 $ENVVAR_TEST 本", @"'\xe6\x97\xa5 $ENVVAR_TEST 本'")]
+        public void SingleQuotedValueShouldParseUntilEnd(string expected, string input) =>
+            Assert.Equal(expected, Parsers.SingleQuotedValue.AtEnd().Parse(input).Value);
 
-            Assert.Equal("\\xe6\\x97\\xa5 $ENVVAR_TEST 本", Parsers.SingleQuotedValue.AtEnd().Parse("'\\xe6\\x97\\xa5 $ENVVAR_TEST 本'").Value);
-
-            Assert.Throws<ParseException>(() => Parsers.SingleQuotedValue.AtEnd().Parse("'a\\'b c'").Value);
-        }
+        [Theory]
+        [InlineData("'a\\'b c'")]
+        public void SingleQuotedValueShouldThrowOnParseUntilEnd(string invalidInput) =>
+            Assert.Throws<ParseException>(() => Parsers.SingleQuotedValue.AtEnd().Parse(invalidInput).Value);
 
         [Fact]
         public void ParseDoubleQuotedValue ()

--- a/test/DotNetEnv.Tests/ParserTests.cs
+++ b/test/DotNetEnv.Tests/ParserTests.cs
@@ -121,14 +121,16 @@ namespace DotNetEnv.Tests
         public void EscapedCharShouldThrowOnParseUntilEnd(string invalidInput) =>
             Assert.Throws<ParseException>(() => Parsers.EscapedChar.AtEnd().Parse(invalidInput));
 
-        [Fact]
-        public void ParseInterpolatedEnvVar ()
-        {
-            Assert.Equal("ENV value", Parsers.InterpolatedEnvVar.AtEnd().Parse("$ENVVAR_TEST").GetValue());
-            Assert.Equal("ENV value", Parsers.InterpolatedBracesEnvVar.AtEnd().Parse("${ENVVAR_TEST}").GetValue());
-        }
+        [Theory]
+        [InlineData("ENV value", "$ENVVAR_TEST")]
+        public void InterpolatedEnvVarShouldParseUntilEnd(string expected, string input) =>
+            Assert.Equal(expected, Parsers.InterpolatedEnvVar.AtEnd().Parse(input).GetValue());
 
-        [Fact]
+        [Theory]
+        [InlineData("ENV value", "${ENVVAR_TEST}")]
+        public void InterpolatedBracesEnvVarShouldParseUntilEnd(string expected, string input) =>
+            Assert.Equal(expected, Parsers.InterpolatedBracesEnvVar.AtEnd().Parse(input).GetValue());
+
         public void ParseInterpolated ()
         {
             Assert.Equal("ENV value", Parsers.InterpolatedValue.AtEnd().Parse("$ENVVAR_TEST").GetValue());

--- a/test/DotNetEnv.Tests/ParserTests.cs
+++ b/test/DotNetEnv.Tests/ParserTests.cs
@@ -405,33 +405,34 @@ namespace DotNetEnv.Tests
         public void AssignmentShouldThrowOnParse(string invalidInput) =>
             Assert.Throws<ParseException>(() => Parsers.Assignment.Parse(invalidInput));
 
-        public static readonly IndexedTheoryData<string, KeyValuePair<string, string>[]> ParseDotEnvTests = new()
-        {
-            { "", Array.Empty<KeyValuePair<string, string>>() },
-            { "EV_DNE=abc", new[] { new KeyValuePair<string, string>("EV_DNE", "abc") } },
-            { "SET EV_DNE=\"0\n1\"", new[] { new KeyValuePair<string, string>("EV_DNE", "0\n1") } },
+        public static readonly TheoryData<string, string, KeyValuePair<string, string>[]> ParseDotEnvTests =
+            new IndexedTheoryData<string, KeyValuePair<string, string>[]>()
             {
-                @"
+                { "", Array.Empty<KeyValuePair<string, string>>() },
+                { "EV_DNE=abc", new[] { new KeyValuePair<string, string>("EV_DNE", "abc") } },
+                { "SET EV_DNE=\"0\n1\"", new[] { new KeyValuePair<string, string>("EV_DNE", "0\n1") } },
+                {
+                    @"
 # this is a header
 
 export EV_DNE='a b c' #works!
 ",
-                new[] { new KeyValuePair<string, string>("EV_DNE", "a b c") }
-            },
-            {
-                "# this is a header\nexport EV_DNE='d e f' #works!",
-                new[] { new KeyValuePair<string, string>("EV_DNE", "d e f") }
-            },
-            {
-                "#\n# this is a header\n#\n\nexport EV_DNE='g h i' #yep still\n",
-                new[] { new KeyValuePair<string, string>("EV_DNE", "g h i") }
-            },
-            {
-                "#\n# this is a header\n#\n\nexport EV_DNE=\"\\xe6\\x97\\xa5 $ENVVAR_TEST 本\" #yep still\n",
-                new[] { new KeyValuePair<string, string>("EV_DNE", "日 ENV value 本") }
-            },
-            {
-                @"#
+                    new[] { new KeyValuePair<string, string>("EV_DNE", "a b c") }
+                },
+                {
+                    "# this is a header\nexport EV_DNE='d e f' #works!",
+                    new[] { new KeyValuePair<string, string>("EV_DNE", "d e f") }
+                },
+                {
+                    "#\n# this is a header\n#\n\nexport EV_DNE='g h i' #yep still\n",
+                    new[] { new KeyValuePair<string, string>("EV_DNE", "g h i") }
+                },
+                {
+                    "#\n# this is a header\n#\n\nexport EV_DNE=\"\\xe6\\x97\\xa5 $ENVVAR_TEST 本\" #yep still\n",
+                    new[] { new KeyValuePair<string, string>("EV_DNE", "日 ENV value 本") }
+                },
+                {
+                    @"#
 # this is a header
 #
 
@@ -445,15 +446,15 @@ SET EV_TEST_2='☠
 
 ENVVAR_TEST = ' yahooooo '
 ",
-                new[]
-                {
-                    new KeyValuePair<string, string>("EV_DNE", "x y z"),
-                    new KeyValuePair<string, string>("EV_TEST_1", "日 $ENVVAR_TEST 本"),
-                    new KeyValuePair<string, string>("EV_TEST_2", "☠\n®"),
-                    new KeyValuePair<string, string>("ENVVAR_TEST", " yahooooo "),
-                }
-            },
-        };
+                    new[]
+                    {
+                        new KeyValuePair<string, string>("EV_DNE", "x y z"),
+                        new KeyValuePair<string, string>("EV_TEST_1", "日 $ENVVAR_TEST 本"),
+                        new KeyValuePair<string, string>("EV_TEST_2", "☠\n®"),
+                        new KeyValuePair<string, string>("ENVVAR_TEST", " yahooooo "),
+                    }
+                },
+            };
 
         [Theory]
         [MemberData(nameof(ParseDotEnvTests))]

--- a/test/DotNetEnv.Tests/ParserTests.cs
+++ b/test/DotNetEnv.Tests/ParserTests.cs
@@ -88,24 +88,15 @@ namespace DotNetEnv.Tests
         public void HexByteShouldParseUntilEnd(byte expected, string input) =>
             Assert.Equal(expected, Parsers.HexByte.AtEnd().Parse(input));
 
-        [Fact]
-        public void ParseUtf8Char ()
-        {
-            // https://stackoverflow.com/questions/602912/how-do-you-echo-a-4-digit-unicode-character-in-bash
-            // printf '\xE2\x98\xA0'
-            // printf ☠ | hexdump  # hexdump has bytes flipped per word (2 bytes, 4 hex)
-
-            Assert.Equal("Z", Parsers.Utf8Char.AtEnd().Parse(@"\x5A"));
-            Assert.Equal("®", Parsers.Utf8Char.AtEnd().Parse(@"\xc2\xae"));
-            Assert.Equal("☠", Parsers.Utf8Char.AtEnd().Parse(@"\xE2\x98\xA0"));
-            Assert.Equal(RocketChar, Parsers.Utf8Char.AtEnd().Parse(@"\xF0\x9F\x9A\x80"));
-
-            Assert.Equal(
-                "日本",
-                Parsers.Utf8Char.AtEnd().Parse(@"\xe6\x97\xa5")
-                    + Parsers.Utf8Char.AtEnd().Parse(@"\xe6\x9c\xac")
-            );
-        }
+        [Theory]
+        [InlineData("Z", @"\x5a")]
+        [InlineData("®", @"\xc2\xae")]
+        [InlineData("☠", @"\xE2\x98\xA0")]
+        [InlineData("日", @"\xe6\x97\xa5")]
+        [InlineData("本", @"\xe6\x9c\xac")]
+        [InlineData(UnicodeChars.Rocket, @"\xF0\x9F\x9A\x80")]
+        public void Utf8CharShouldParseUntilEnd(string expected, string input) =>
+            Assert.Equal(expected, Parsers.Utf8Char.AtEnd().Parse(input));
 
         [Fact]
         public void ParseUtf16Char ()
@@ -535,6 +526,16 @@ ENVVAR_TEST = ' yahooooo '
                 new KeyValuePair<string, string>("ENVVAR_TEST", " yahooooo "),
             };
             testParse(expecteds, contents);
+        }
+
+        // C# wow that you can't handle 32 bit unicode as chars. wow. strings for 4 byte chars.
+        private struct UnicodeChars
+        {
+            // https://stackoverflow.com/questions/602912/how-do-you-echo-a-4-digit-unicode-character-in-bash
+            // printf '\xE2\x98\xA0'
+            // printf ☠ | hexdump  # hexdump has bytes flipped per word (2 bytes, 4 hex)
+
+            public const string Rocket = "\ud83d\ude80"; // 🚀
         }
     }
 }

--- a/test/DotNetEnv.Tests/XUnit/IndexedTheoryData.cs
+++ b/test/DotNetEnv.Tests/XUnit/IndexedTheoryData.cs
@@ -20,3 +20,12 @@ public class IndexedTheoryData<T1, T2> : TheoryData
         AddRow($"{_index++,4}; {callerMemberName}:{callerLineNumber}", p1, p2);
     }
 }
+
+public class IndexedTheoryData<T1, T2, T3> : TheoryData
+{
+    private int _index = 0;
+    public void Add(T1 p1, T2 p2, T3 p3, [CallerMemberName]string callerMemberName = null, [CallerLineNumber]int callerLineNumber = 0)
+    {
+        AddRow($"{_index++,4}; {callerMemberName}:{callerLineNumber}", p1, p2, p3);
+    }
+}

--- a/test/DotNetEnv.Tests/XUnit/IndexedTheoryData.cs
+++ b/test/DotNetEnv.Tests/XUnit/IndexedTheoryData.cs
@@ -3,7 +3,7 @@ using Xunit;
 
 namespace DotNetEnv.Tests.XUnit;
 
-public class IndexedTheoryData<T> : TheoryData
+public class IndexedTheoryData<T> : TheoryData<string, T>
 {
     private int _index = 0;
     public void Add(T p, [CallerMemberName]string callerMemberName = null, [CallerLineNumber]int callerLineNumber = 0)
@@ -12,7 +12,7 @@ public class IndexedTheoryData<T> : TheoryData
     }
 }
 
-public class IndexedTheoryData<T1, T2> : TheoryData
+public class IndexedTheoryData<T1, T2> : TheoryData<string, T1, T2>
 {
     private int _index = 0;
     public void Add(T1 p1, T2 p2, [CallerMemberName]string callerMemberName = null, [CallerLineNumber]int callerLineNumber = 0)
@@ -21,7 +21,7 @@ public class IndexedTheoryData<T1, T2> : TheoryData
     }
 }
 
-public class IndexedTheoryData<T1, T2, T3> : TheoryData
+public class IndexedTheoryData<T1, T2, T3> : TheoryData<string, T1, T2, T3>
 {
     private int _index = 0;
     public void Add(T1 p1, T2 p2, T3 p3, [CallerMemberName]string callerMemberName = null, [CallerLineNumber]int callerLineNumber = 0)

--- a/test/DotNetEnv.Tests/XUnit/IndexedTheoryData.cs
+++ b/test/DotNetEnv.Tests/XUnit/IndexedTheoryData.cs
@@ -29,3 +29,12 @@ public class IndexedTheoryData<T1, T2, T3> : TheoryData<string, T1, T2, T3>
         AddRow($"{_index++,4}; {callerMemberName}:{callerLineNumber}", p1, p2, p3);
     }
 }
+
+public class IndexedTheoryData<T1, T2, T3, T4> : TheoryData<string, T1, T2, T3, T4>
+{
+    private int _index = 0;
+    public void Add(T1 p1, T2 p2, T3 p3, T4 p4, [CallerMemberName]string callerMemberName = null, [CallerLineNumber]int callerLineNumber = 0)
+    {
+        AddRow($"{_index++,4}; {callerMemberName}:{callerLineNumber}", p1, p2, p3, p4);
+    }
+}

--- a/test/DotNetEnv.Tests/XUnit/IndexedTheoryData.cs
+++ b/test/DotNetEnv.Tests/XUnit/IndexedTheoryData.cs
@@ -1,0 +1,13 @@
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace DotNetEnv.Tests.XUnit;
+
+public class IndexedTheoryData<TData> : TheoryData
+{
+    private int _index = 0;
+    public void Add(TData p1, [CallerMemberName]string callerMemberName = null, [CallerLineNumber]int callerLineNumber = 0)
+    {
+        AddRow($"{_index++,4}; {callerMemberName}:{callerLineNumber}", p1);
+    }
+}

--- a/test/DotNetEnv.Tests/XUnit/IndexedTheoryData.cs
+++ b/test/DotNetEnv.Tests/XUnit/IndexedTheoryData.cs
@@ -3,11 +3,20 @@ using Xunit;
 
 namespace DotNetEnv.Tests.XUnit;
 
-public class IndexedTheoryData<TData> : TheoryData
+public class IndexedTheoryData<T> : TheoryData
 {
     private int _index = 0;
-    public void Add(TData p1, [CallerMemberName]string callerMemberName = null, [CallerLineNumber]int callerLineNumber = 0)
+    public void Add(T p, [CallerMemberName]string callerMemberName = null, [CallerLineNumber]int callerLineNumber = 0)
     {
-        AddRow($"{_index++,4}; {callerMemberName}:{callerLineNumber}", p1);
+        AddRow($"{_index++,4}; {callerMemberName}:{callerLineNumber}", p);
+    }
+}
+
+public class IndexedTheoryData<T1, T2> : TheoryData
+{
+    private int _index = 0;
+    public void Add(T1 p1, T2 p2, [CallerMemberName]string callerMemberName = null, [CallerLineNumber]int callerLineNumber = 0)
+    {
+        AddRow($"{_index++,4}; {callerMemberName}:{callerLineNumber}", p1, p2);
     }
 }


### PR DESCRIPTION
While doing major changes (eg changing from Sprache to Superpower) I had some trouble with testing, because the current Fact-Methods do fail at the first failing case. That way it is hard to check whether you fixed something and just broke a different case, or if it does not fix the intended case at all.
Additionally you always have to care about whether the testcases within a method are really "the same", or if for example some check "AtEnd" and some do not.

That's where Theories come into action.
They reduce many of the test-methods to one-liners, which prevents you from merging different aspects of testing.
Instead it enforces to have a precise test-statements which should be tested with different inputs.

Additionally it reports each single failing input instead of just failing at the first of them.

Is that something you would support?
It is not finished, and of course some scenarios have to be handled differently, we should not parse an entire file for each single test for example.

It's not really possible to check that request via git-compare at the moment, too many changes which are not recognized in the correct order.
If there is an interest in having this, I'd split this commit into single method-change-commits to enable a proper review.
And it is of course still a draft, it is not even fully finished for ParserTests.